### PR TITLE
[DPE-6480] Add discourse overview link

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,6 +2,8 @@
 # See LICENSE file for licensing details.
 
 type: charm
+links:
+  documentation: https://discourse.charmhub.io/t/16755
 platforms:
   ubuntu@22.04:amd64:
 # Files implicitly created by charmcraft without a part:


### PR DESCRIPTION
## Changes

- Add link to discourse [overview](https://discourse.charmhub.io/t/charmed-apache-kyuubi-k8s-documentation/16755)

Prior discussions can be found in #57 