### PR TITLE
[DPE-6480] Move docs link from charmcraft.yaml to metadata.yaml

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,8 +2,6 @@
 # See LICENSE file for licensing details.
 
 type: charm
-links:
-  documentation: https://discourse.charmhub.io/t/16755
 platforms:
   ubuntu@22.04:amd64:
 # Files implicitly created by charmcraft without a part:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,6 +12,7 @@ description: |
 
   Apache Kyuubi is a free, open source software project by the Apache Software Foundation. 
   Users can find out more at the [Kyuubi project page](https://kyuubi.apache.org/).
+docs: https://discourse.charmhub.io/t/charmed-apache-kyuubi-k8s-documentation/16755
 source: https://github.com/canonical/kyuubi-k8s-operator
 issues: https://github.com/canonical/kyuubi-k8s-operator/issues
 website:


### PR DESCRIPTION
Let's try to fix the missing content from https://charmhub.io/kyuubi-k8s