### PR TITLE
[DPE-6570] Defer events leading to service update if container is unreachable

### DIFF
--- a/src/core/workload/__init__.py
+++ b/src/core/workload/__init__.py
@@ -7,6 +7,8 @@
 from abc import abstractmethod
 from pathlib import Path
 
+from ops import Container
+
 from common.workload import AbstractWorkload
 
 
@@ -82,6 +84,7 @@ class KyuubiWorkloadBase(AbstractWorkload):
     """Base interface for common workload operations."""
 
     paths: KyuubiPaths
+    container: Container
 
     def restart(self) -> None:
         """Restarts the workload service."""

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -109,7 +109,7 @@ class TLSEvents(BaseEventHandler, WithLogging):
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Handler for `certificates_available` event after provider updates signed certs."""
         # avoid setting tls files and restarting
-        if not self.workload.container.can_connect():
+        if not self.workload.ready():
             event.defer()
             return
 
@@ -158,7 +158,7 @@ class TLSEvents(BaseEventHandler, WithLogging):
     @defer_when_not_ready
     def _on_certificates_broken(self, event: RelationBrokenEvent) -> None:
         """Handler for `certificates_relation_broken` event."""
-        if not self.workload.container.can_connect():
+        if not self.workload.ready():
             event.defer()
             return
 

--- a/src/events/zookeeper.py
+++ b/src/events/zookeeper.py
@@ -6,6 +6,7 @@
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequirerEventHandlers
 from ops import CharmBase
+from ops.charm import RelationChangedEvent
 
 from constants import ZOOKEEPER_REL
 from core.context import Context
@@ -38,8 +39,11 @@ class ZookeeperEvents(BaseEventHandler, WithLogging):
         )
 
     @compute_status
-    def _on_zookeeper_changed(self, _):
+    def _on_zookeeper_changed(self, event: RelationChangedEvent):
         self.logger.info("Zookeeper relation changed new...")
+        if not self.workload.container.can_connect():
+            event.defer()
+            return
         self.kyuubi.update()
 
     @compute_status

--- a/src/events/zookeeper.py
+++ b/src/events/zookeeper.py
@@ -41,7 +41,7 @@ class ZookeeperEvents(BaseEventHandler, WithLogging):
     @compute_status
     def _on_zookeeper_changed(self, event: RelationChangedEvent):
         self.logger.info("Zookeeper relation changed new...")
-        if not self.workload.container.can_connect():
+        if not self.workload.ready():
             event.defer()
             return
         self.kyuubi.update()
@@ -49,7 +49,7 @@ class ZookeeperEvents(BaseEventHandler, WithLogging):
     @compute_status
     def _on_zookeeper_broken(self, event: RelationBrokenEvent):
         self.logger.info("Zookeeper relation broken...")
-        if not self.workload.container.can_connect():
+        if not self.workload.ready():
             event.defer()
             return
         self.kyuubi.update(set_zookeeper_none=True)


### PR DESCRIPTION
# Changes

We usually give the charm the courtesy of "settling down" before adding / removing relations in our tests.
This approach is not representative of a bundle deployment, where everything is dumped at once.
We found out that one of the leading reasons for bundle CI instability was trying to access the workload container while it is unreachable:

<details><summary>Example with ZooKeeper</summary>

```
2025-02-07T14:41:29.584Z [container-agent] Traceback (most recent call last):
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/src/charm.py", line 87, in <module>
2025-02-07T14:41:29.584Z [container-agent]     ops.main(KyuubiCharm)  # type: ignore
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/venv/lib/python3.10/site-packages/ops/__init__.py", line 343, in __call__
2025-02-07T14:41:29.584Z [container-agent]     return _main.main(charm_class=charm_class, use_juju_for_storage=use_juju_for_storage)
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/venv/lib/python3.10/site-packages/ops/_main.py", line 543, in main
2025-02-07T14:41:29.584Z [container-agent]     manager.run()
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/venv/lib/python3.10/site-packages/ops/_main.py", line 529, in run
2025-02-07T14:41:29.584Z [container-agent]     self._emit()
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/venv/lib/python3.10/site-packages/ops/_main.py", line 518, in _emit
2025-02-07T14:41:29.584Z [container-agent]     _emit_charm_event(self.charm, self.dispatcher.event_name, self._juju_context)
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/venv/lib/python3.10/site-packages/ops/_main.py", line 134, in _emit_charm_event
2025-02-07T14:41:29.584Z [container-agent]     event_to_emit.emit(*args, **kwargs)
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/venv/lib/python3.10/site-packages/ops/framework.py", line 347, in emit
2025-02-07T14:41:29.584Z [container-agent]     framework._emit(event)
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/venv/lib/python3.10/site-packages/ops/framework.py", line 857, in _emit
2025-02-07T14:41:29.584Z [container-agent]     self._reemit(event_path)
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/venv/lib/python3.10/site-packages/ops/framework.py", line 947, in _reemit
2025-02-07T14:41:29.584Z [container-agent]     custom_handler(event)
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/src/events/base.py", line 85, in wrapper_hook
2025-02-07T14:41:29.584Z [container-agent]     res = hook(event_handler, event)
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/src/events/zookeeper.py", line 43, in _on_zookeeper_changed
2025-02-07T14:41:29.584Z [container-agent]     self.kyuubi.update()
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/src/managers/kyuubi.py", line 62, in update
2025-02-07T14:41:29.584Z [container-agent]     self._compare_and_update_file(
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/src/managers/kyuubi.py", line 31, in _compare_and_update_file
2025-02-07T14:41:29.584Z [container-agent]     existing_content = self.workload.read(file_path)
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/src/common/workload/k8s.py", line 45, in read
2025-02-07T14:41:29.584Z [container-agent]     if not self.container.exists(path):
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/venv/lib/python3.10/site-packages/ops/model.py", line 2852, in exists
2025-02-07T14:41:29.584Z [container-agent]     self._pebble.list_files(str(path), itself=True)
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/venv/lib/python3.10/site-packages/ops/pebble.py", line 2616, in list_files
2025-02-07T14:41:29.584Z [container-agent]     resp = self._request('GET', '/v1/files', query)
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/venv/lib/python3.10/site-packages/ops/pebble.py", line 2010, in _request
2025-02-07T14:41:29.584Z [container-agent]     response = self._request_raw(method, path, query, headers, data)
2025-02-07T14:41:29.584Z [container-agent]   File "/var/lib/juju/agents/unit-kyuubi-0/charm/venv/lib/python3.10/site-packages/ops/pebble.py", line 2063, in _request_raw
2025-02-07T14:41:29.584Z [container-agent]     raise ConnectionError(
2025-02-07T14:41:29.584Z [container-agent] ops.pebble.ConnectionError: Could not connect to Pebble: socket not found at '/charm/containers/kyuubi/pebble.socket' (container restarted?)
```

</details>

This PR adds a check on the event handlers responsible for a `kyuubi.update` leading to a `ConnectionError` in my various attempts to get green CI on the spark bundle.

A temporary charm release was created from commit 1b63bc6f1da34298a0b2e660dc203b3894bb2dda, and is used as part of the bundle CI in the following PR: https://github.com/canonical/spark-k8s-bundle/pull/82 (all tests using this revision green first try!)

This PR is fairly conservative, and only adds the checks for event handlers where I witnessed this issue: tls and zk. We can generalize this pattern to all event handlers leading to a service update if needed.