### PR TITLE
[DPE-6692] Prevent running actions on non-leader units

### DIFF
--- a/src/events/base.py
+++ b/src/events/base.py
@@ -4,10 +4,11 @@
 
 """Base utilities exposing common functionalities for all Events classes."""
 
-from functools import wraps
-from typing import Callable
+from __future__ import annotations
 
-from charms.data_platform_libs.v0.data_models import TypedCharmBase
+from functools import wraps
+from typing import TYPE_CHECKING, Callable
+
 from ops import EventBase, Object, StatusBase
 
 from core.context import Context
@@ -17,12 +18,15 @@ from managers.k8s import K8sManager
 from managers.service import ServiceManager
 from utils.logging import WithLogging
 
+if TYPE_CHECKING:
+    from charm import KyuubiCharm
+
 
 class BaseEventHandler(Object, WithLogging):
     """Base class for all Event Handler classes in the Spark Integration Hub."""
 
     workload: KyuubiWorkloadBase
-    charm: TypedCharmBase
+    charm: KyuubiCharm
     context: Context
 
     def get_app_status(  # noqa: C901
@@ -75,7 +79,7 @@ class BaseEventHandler(Object, WithLogging):
 
 
 def compute_status(
-    hook: Callable[[BaseEventHandler, EventBase], None]
+    hook: Callable[[BaseEventHandler, EventBase], None],
 ) -> Callable[[BaseEventHandler, EventBase], None]:
     """Decorator to automatically compute statuses at the end of the hook."""
 
@@ -92,7 +96,7 @@ def compute_status(
 
 
 def defer_when_not_ready(
-    hook: Callable[[BaseEventHandler, EventBase], None]
+    hook: Callable[[BaseEventHandler, EventBase], None],
 ) -> Callable[[BaseEventHandler, EventBase], None]:
     """Decorator to defer hook is workload is not ready."""
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -186,9 +186,9 @@ async def get_kyuubi_pid(ops_test: OpsTest, unit):
         "aux",
     ]
     process = subprocess.run(command, capture_output=True, check=True)
-    assert process.returncode == 0, (
-        f"Command: {command} returned with return code {process.returncode}"
-    )
+    assert (
+        process.returncode == 0
+    ), f"Command: {command} returned with return code {process.returncode}"
 
     for line in process.stdout.decode().splitlines():
         match = re.search(re.escape(PROCESS_NAME_PATTERN), line)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -58,7 +58,9 @@ def check_status(entity: Application | Unit, status: StatusBase):
 async def fetch_jdbc_endpoint(ops_test):
     """Return the JDBC endpoint for clients to connect to Kyuubi server."""
     logger.info("Running action 'get-jdbc-endpoint' on kyuubi-k8s unit...")
-    kyuubi_unit = ops_test.model.applications[APP_NAME].units[0]
+    for unit in ops_test.model.applications[APP_NAME].units:
+        if await unit.is_leader_from_status():
+            kyuubi_unit = unit
     action = await kyuubi_unit.run_action(
         action_name="get-jdbc-endpoint",
     )
@@ -184,9 +186,9 @@ async def get_kyuubi_pid(ops_test: OpsTest, unit):
         "aux",
     ]
     process = subprocess.run(command, capture_output=True, check=True)
-    assert (
-        process.returncode == 0
-    ), f"Command: {command} returned with return code {process.returncode}"
+    assert process.returncode == 0, (
+        f"Command: {command} returned with return code {process.returncode}"
+    )
 
     for line in process.stdout.decode().splitlines():
         match = re.search(re.escape(PROCESS_NAME_PATTERN), line)
@@ -224,7 +226,7 @@ async def is_entire_cluster_responding_requests(ops_test: OpsTest, test_pod) -> 
     kyuubi_pods = {
         unit.name.replace("/", "-") for unit in ops_test.model.applications[APP_NAME].units
     }
-    logger.info(f"Nodes in the cluster being tested: " f"{','.join(kyuubi_pods)}")
+    logger.info(f"Nodes in the cluster being tested: {','.join(kyuubi_pods)}")
     pods_that_responded = set()
 
     tries = 0
@@ -246,9 +248,7 @@ async def is_entire_cluster_responding_requests(ops_test: OpsTest, test_pod) -> 
             *pod_command,
         ]
         command_executed_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
-        logger.info(
-            f"Executing command: {' '.join(kubectl_command)} " f"at {command_executed_at}..."
-        )
+        logger.info(f"Executing command: {' '.join(kubectl_command)} at {command_executed_at}...")
         process = subprocess.run(kubectl_command, capture_output=True, check=True)
         assert process.returncode == 0
 

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Limited
+# See LICENSE file for licensing details.
+
 import dataclasses
 import json
 import logging

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -1,0 +1,130 @@
+import dataclasses
+import json
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from ops.testing import ActionFailed, Container, Context, Relation, State
+
+from charm import KyuubiCharm
+from constants import KYUUBI_CONTAINER_NAME
+from core.domain import Status
+
+logger = logging.getLogger(__name__)
+
+
+CONFIG = yaml.safe_load(Path("./config.yaml").read_text())
+ACTIONS = yaml.safe_load(Path("./actions.yaml").read_text())
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+
+@pytest.fixture()
+def charm_configuration():
+    """Enable direct mutation on configuration dict."""
+    return json.loads(json.dumps(CONFIG))
+
+
+@pytest.fixture()
+def base_state():
+    return State(leader=True, containers=[Container(name=KYUUBI_CONTAINER_NAME, can_connect=True)])
+
+
+@pytest.fixture()
+def ctx() -> Context:
+    ctx = Context(
+        KyuubiCharm,
+        meta=METADATA,
+        config=CONFIG,
+        actions=ACTIONS,
+    )
+    return ctx
+
+
+@pytest.mark.parametrize(
+    ["action"], [("get-password",), ("set-password",), ("get-jdbc-endpoint",)]
+)
+def test_action_not_leader(action: str, ctx: Context, base_state: State) -> None:
+    # Given
+    state_in = dataclasses.replace(base_state, leader=False)
+
+    # When
+    # Then
+    with pytest.raises(ActionFailed) as exc_info:
+        _ = ctx.run(ctx.on.action(action), state_in)
+
+    assert exc_info.value.message == "Action must be ran on the application leader"
+
+
+@pytest.mark.parametrize(["action"], [("get-password",), ("set-password",)])
+def test_password_action_not_related(ctx: Context, base_state: State, action: str) -> None:
+    # Given
+    state_in = base_state
+
+    # When
+    # Then
+    with pytest.raises(ActionFailed) as exc_info:
+        _ = ctx.run(ctx.on.action(action), state_in)
+
+    assert "The action can only be run when authentication is enabled" in exc_info.value.message
+
+
+@pytest.mark.parametrize(
+    ["action"], [("get-password",), ("set-password",), ("get-jdbc-endpoint",)]
+)
+def test_action_workload_not_ready(ctx: Context, action: str) -> None:
+    # Given
+    relation_db = Relation(
+        "auth-db",
+        "postgresql_client",
+        remote_app_data={
+            "endpoints": "127.0.0.1:5432",
+            "username": "speakfriend",
+            "password": "mellon",
+            "database": "lotr",
+        },
+    )
+    state_in = State(
+        leader=True,
+        containers=[Container(name=KYUUBI_CONTAINER_NAME, can_connect=False)],
+        relations=[relation_db],
+    )
+
+    # When
+    # Then
+    with pytest.raises(ActionFailed) as exc_info:
+        _ = ctx.run(ctx.on.action(action), state_in)
+
+    assert exc_info.value.message == "The action failed because the workload is not ready yet."
+
+
+@pytest.mark.parametrize(
+    ["action"], [("get-password",), ("set-password",), ("get-jdbc-endpoint",)]
+)
+def test_action_workload_not_active(ctx: Context, base_state: State, action: str) -> None:
+    # Given
+    relation_db = Relation(
+        "auth-db",
+        "postgresql_client",
+        remote_app_data={
+            "endpoints": "127.0.0.1:5432",
+            "username": "speakfriend",
+            "password": "mellon",
+            "database": "lotr",
+        },
+    )
+    state_in = dataclasses.replace(base_state, relations=[relation_db])
+
+    # When
+    # Then
+    with (
+        patch(
+            "events.base.BaseEventHandler.get_app_status",
+            return_value=Status.MISSING_OBJECT_STORAGE_BACKEND,
+        ),
+        pytest.raises(ActionFailed) as exc_info,
+    ):
+        _ = ctx.run(ctx.on.action(action), state_in)
+
+    assert exc_info.value.message == "The action failed because the charm is not in active state."


### PR DESCRIPTION
## Changes

- Added a check so that running "get-password" on a non-leader unit gives a more understandable message. Since two out of three actions requires running on the leader unit, I also applied the same standard to "get-jdbc-endpoint". From a UX perspective, I think this consistency is nice to have. However, I can easily revert if needed
- Improved type hints a little bit so that we avoid a few `type: ignore` comments