### PR TITLE
[DPE-6890] Wire up loadbalancer-extra-annotations to service creation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,20 +4,20 @@
 options:
   namespace:
     type: string
-    description: The namespace to be used by driver to create executor pods. If not configured, the model namespace will be used. 
-    default: ''
+    description: The namespace to be used by driver to create executor pods. If not configured, the model namespace will be used.
+    default: ""
   service-account:
     type: string
     description: The service account to be used by driver to create executor pods.
-    default: 'kyuubi-spark-engine'
+    default: "kyuubi-spark-engine"
   expose-external:
     type: string
     description: The mode in which the service should be exposed externally. Valid values are false, nodeport and loadbalancer.
-    default: 'false' 
+    default: "false"
   loadbalancer-extra-annotations:
     type: string
     description: Optional extra annotations to be supplied to the load balancer service.
-    default: ''
+    default: "{}"
   enable-dynamic-allocation:
     type: boolean
     description: Enable dynamic allocation of pods for Spark jobs.

--- a/src/events/kyuubi.py
+++ b/src/events/kyuubi.py
@@ -72,7 +72,9 @@ class KyuubiEvents(BaseEventHandler, WithLogging):
         """Handle the on_config_changed event."""
         if self.charm.unit.is_leader():
             # Create / update the managed service to reflect the service type in config
-            self.service_manager.reconcile_services(self.charm.config.expose_external)
+            self.service_manager.reconcile_services(
+                self.charm.config.expose_external, self.charm.config.loadbalancer_extra_annotations
+            )
 
         self.kyuubi.update()
 

--- a/src/managers/service.py
+++ b/src/managers/service.py
@@ -234,8 +234,10 @@ class ServiceManager(WithLogging):
             )
             annotations = {}
         if existing_service is not None:
-            is_same_service = _ServiceType(existing_service.spec.type) == desired_service_type  # type: ignore
-            has_same_annotations = existing_service.metadata.annotations == annotations  # type: ignore
+            existing_service_type = getattr(existing_service.spec, "type")
+            is_same_service = _ServiceType(existing_service_type) == desired_service_type
+            existing_annotations: dict = getattr(existing_service.metadata, "annotations")
+            has_same_annotations = existing_annotations == annotations
 
             if is_same_service and has_same_annotations:
                 self.logger.info(
@@ -249,7 +251,7 @@ class ServiceManager(WithLogging):
 
         self.create_service(
             service_type=desired_service_type,
-            owner_references=pod0.metadata.ownerReferences,  # type: ignore
+            owner_references=getattr(pod0.metadata, "ownerReferences", []),
             annotations=annotations,
         )
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -15,6 +15,7 @@ from typing import List, cast
 
 import jubilant
 import lightkube
+from lightkube.resources.core_v1 import Service
 import requests
 import yaml
 from spark8t.domain import PropertyFile
@@ -581,7 +582,7 @@ def deploy_minimal_kyuubi_setup(
     logger.info("Successfully deployed minimal working Kyuubi setup.")
 
 
-def get_k8s_service(namespace: str, service_name: str):
+def get_k8s_service(namespace: str, service_name: str) -> Service | None:
     client = lightkube.Client()
     try:
         service = client.get(
@@ -635,7 +636,7 @@ def umask_named_temporary_file(*args, **kargs):
 def assert_service_status(
     namespace: str,
     service_type: str,
-):
+) -> Service:
     """Utility function to check status of managed K8s service created by Kyuubi charm."""
     service_name = f"{APP_NAME}-service"
     service = get_k8s_service(namespace=namespace, service_name=service_name)
@@ -655,6 +656,8 @@ def assert_service_status(
 
     if service_type in ("NodePort", "LoadBalancer"):
         assert NODEPORT_MIN_VALUE <= service_port.nodePort <= NODEPORT_MAX_VALUE
+
+    return service
 
 
 def fetch_spark_properties(juju: jubilant.Juju, unit_name: str) -> dict[str, str]:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -15,9 +15,9 @@ from typing import List, cast
 
 import jubilant
 import lightkube
-from lightkube.resources.core_v1 import Service
 import requests
 import yaml
+from lightkube.resources.core_v1 import Service
 from spark8t.domain import PropertyFile
 from spark_test.core.kyuubi import KyuubiClient
 
@@ -645,17 +645,21 @@ def assert_service_status(
     assert service is not None
 
     service_spec = service.spec
+    assert service_spec is not None
     assert service_type == service_spec.type
     assert service_spec.selector == {"app.kubernetes.io/name": APP_NAME}
 
+    assert service_spec.ports is not None
     service_port = service_spec.ports[0]
+    assert service_port is not None
     assert service_port.port == JDBC_PORT
     assert service_port.targetPort == JDBC_PORT
     assert service_port.name == JDBC_PORT_NAME
     assert service_port.protocol == "TCP"
 
     if service_type in ("NodePort", "LoadBalancer"):
-        assert NODEPORT_MIN_VALUE <= service_port.nodePort <= NODEPORT_MAX_VALUE
+        assert service_port.nodePort is not None
+        assert NODEPORT_MIN_VALUE <= int(service_port.nodePort) <= NODEPORT_MAX_VALUE
 
     return service
 


### PR DESCRIPTION
# Changes

- Implement `loadbalancer-extra-annotations` to add annotation to the K8s LB service

**Important** 
I quickly checked on the testing AKS playground if we can deal with certs just by using the "correct" annotation setting up the hostname, and it appears that we will need some additional logic if we want to include a hostname in the certs from an annotation.
The current ManSol deployment strategy sets a hostname as ca name at the self-signed-certificates level, but the get-jdbc-endpoint action will return an IP. This IP will be set in the welcome email template. We might need to work with ManSol on that aspect.