### PR TITLE
[DPE-7061] Make auth db relation mandatory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,9 +92,9 @@ jobs:
         # TODO: Replace with custom image on self-hosted runner
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.4/stable
+          juju-channel: 3.6/stable
           provider: microk8s
-          channel: 1.30-strict/stable
+          channel: 1.32-strict/stable
           microk8s-group: snap_microk8s
           microk8s-addons: "rbac hostpath-storage dns minio metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
       - name: Download packed charm(s)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Get prefsrc
+        # One IP needed to test external access
         run: |
           echo "IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')" >> $GITHUB_ENV
       - name: Setup operator environment

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,6 +120,6 @@ jobs:
             echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
       - name: Run integration tests
-        run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
+        run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' --keep-models
         env:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
+      - name: (GitHub hosted) Free up disk space
+        shell: bash
+        run: |
+          printf '\nDisk usage before cleanup\n'
+          df --human-readable
+          # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+          rm -r /usr/share/dotnet
+          rm -r /opt/hostedtoolcache/
+          printf '\nDisk usage after cleanup\n'
+          df --human-readable
       - name: Checkout
         uses: actions/checkout@v4
       - name: Get prefsrc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,11 +80,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "17"
       - name: Get prefsrc
         run: |
           echo "IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')" >> $GITHUB_ENV

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -43,21 +43,24 @@ peers:
     interface: upgrade
 
 requires:
-  metastore-db:
-    interface: postgresql_client
-    limit: 1
   auth-db:
     interface: postgresql_client
     limit: 1
   spark-service-account:
     interface: spark_service_account
     limit: 1
+  metastore-db:
+    interface: postgresql_client
+    limit: 1
+    optional: true
   zookeeper:
     interface: zookeeper
     limit: 1
+    optional: true
   logging:
     interface: loki_push_api
     limit: 1
+    optional: true
   certificates:
     interface: tls-certificates
     limit: 1

--- a/poetry.lock
+++ b/poetry.lock
@@ -237,41 +237,6 @@ tests = ["pytest (>=3.2.1,!=3.3.0)"]
 typecheck = ["mypy"]
 
 [[package]]
-name = "black"
-version = "22.12.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.7"
-groups = ["format", "lint"]
-files = [
-    {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
-    {file = "black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351"},
-    {file = "black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"},
-    {file = "black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4"},
-    {file = "black-22.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2"},
-    {file = "black-22.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350"},
-    {file = "black-22.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d"},
-    {file = "black-22.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc"},
-    {file = "black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320"},
-    {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
-    {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
-    {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "boto3"
 version = "1.35.99"
 description = "The AWS SDK for Python"
@@ -519,21 +484,6 @@ files = [
 ]
 
 [[package]]
-name = "click"
-version = "8.1.8"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-groups = ["format", "lint"]
-files = [
-    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
-    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[[package]]
 name = "codespell"
 version = "2.4.1"
 description = "Fix common misspellings in text files"
@@ -557,12 +507,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["format", "integration", "lint", "unit"]
+groups = ["integration", "unit"]
+markers = "sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {format = "platform_system == \"Windows\"", integration = "sys_platform == \"win32\"", lint = "platform_system == \"Windows\"", unit = "sys_platform == \"win32\""}
 
 [[package]]
 name = "cosl"
@@ -1277,7 +1227,7 @@ version = "1.1.0"
 description = "Type system extensions for programs checked with the mypy type checker."
 optional = false
 python-versions = ">=3.8"
-groups = ["format", "integration", "lint"]
+groups = ["integration"]
 files = [
     {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
     {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
@@ -1388,18 +1338,6 @@ qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
 testing = ["docopt", "pytest"]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.8"
-groups = ["format", "lint"]
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
-
-[[package]]
 name = "pexpect"
 version = "4.9.0"
 description = "Pexpect allows easy control of interactive console applications."
@@ -1414,23 +1352,6 @@ files = [
 
 [package.dependencies]
 ptyprocess = ">=0.5"
-
-[[package]]
-name = "platformdirs"
-version = "4.3.7"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
-optional = false
-python-versions = ">=3.9"
-groups = ["format", "lint"]
-files = [
-    {file = "platformdirs-4.3.7-py3-none-any.whl", hash = "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94"},
-    {file = "platformdirs-4.3.7.tar.gz", hash = "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351"},
-]
-
-[package.extras]
-docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.4)", "pytest-cov (>=6)", "pytest-mock (>=3.14)"]
-type = ["mypy (>=1.14.1)"]
 
 [[package]]
 name = "pluggy"
@@ -2317,7 +2238,8 @@ version = "2.2.1"
 description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
-groups = ["format", "integration", "lint", "unit"]
+groups = ["integration", "unit"]
+markers = "python_full_version <= \"3.11.0a6\""
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
     {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
@@ -2352,7 +2274,6 @@ files = [
     {file = "tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"},
     {file = "tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"},
 ]
-markers = {format = "python_full_version < \"3.11.0a7\"", integration = "python_full_version <= \"3.11.0a6\"", lint = "python_full_version < \"3.11.0a7\"", unit = "python_full_version <= \"3.11.0a6\""}
 
 [[package]]
 name = "toposort"
@@ -2540,4 +2461,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "23b184b1235fbdc9d16ef72ece1ac496b802724b9d2cf609e8bdd4d0e6624f29"
+content-hash = "879c1f441100ec4bdfcc43d3f2aef32dabd13d38e899797c47db4d31d9459a60"

--- a/poetry.lock
+++ b/poetry.lock
@@ -61,14 +61,14 @@ tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "azure-core"
-version = "1.32.0"
+version = "1.33.0"
 description = "Microsoft Azure Core Library for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["integration"]
 files = [
-    {file = "azure_core-1.32.0-py3-none-any.whl", hash = "sha256:eac191a0efb23bfa83fddf321b27b122b4ec847befa3091fa736a5c32c50d7b4"},
-    {file = "azure_core-1.32.0.tar.gz", hash = "sha256:22b3c35d6b2dae14990f6c1be2912bf23ffe50b220e708a28ab1bb92b1c730e5"},
+    {file = "azure_core-1.33.0-py3-none-any.whl", hash = "sha256:9b5b6d0223a1d38c37500e6971118c1e0f13f54951e6893968b38910bc9cda8f"},
+    {file = "azure_core-1.33.0.tar.gz", hash = "sha256:f367aa07b5e3005fec2c1e184b882b0b039910733907d001c20fb08ebb8c0eb9"},
 ]
 
 [package.dependencies]
@@ -78,6 +78,7 @@ typing-extensions = ">=4.6.0"
 
 [package.extras]
 aio = ["aiohttp (>=3.0)"]
+tracing = ["opentelemetry-api (>=1.26,<2.0)"]
 
 [[package]]
 name = "azure-storage-blob"
@@ -789,14 +790,14 @@ files = [
 
 [[package]]
 name = "google-auth"
-version = "2.38.0"
+version = "2.39.0"
 description = "Google Authentication Library"
 optional = false
 python-versions = ">=3.7"
 groups = ["integration"]
 files = [
-    {file = "google_auth-2.38.0-py2.py3-none-any.whl", hash = "sha256:e7dae6694313f434a2727bf2906f27ad259bae090d7aa896590d86feec3d9d4a"},
-    {file = "google_auth-2.38.0.tar.gz", hash = "sha256:8285113607d3b80a3f1543b75962447ba8a09fe85783432a784fdeef6ac094c4"},
+    {file = "google_auth-2.39.0-py2.py3-none-any.whl", hash = "sha256:0150b6711e97fb9f52fe599f55648950cc4540015565d8fbb31be2ad6e1548a2"},
+    {file = "google_auth-2.39.0.tar.gz", hash = "sha256:73222d43cdc35a3aeacbfdcaf73142a97839f10de930550d89ebfe1d0a00cde7"},
 ]
 
 [package.dependencies]
@@ -805,12 +806,14 @@ pyasn1-modules = ">=0.2.1"
 rsa = ">=3.1.4,<5"
 
 [package.extras]
-aiohttp = ["aiohttp (>=3.6.2,<4.0.0.dev0)", "requests (>=2.20.0,<3.0.0.dev0)"]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0)", "requests (>=2.20.0,<3.0.0)"]
 enterprise-cert = ["cryptography", "pyopenssl"]
-pyjwt = ["cryptography (>=38.0.3)", "pyjwt (>=2.0)"]
-pyopenssl = ["cryptography (>=38.0.3)", "pyopenssl (>=20.0.0)"]
+pyjwt = ["cryptography (<39.0.0)", "cryptography (>=38.0.3)", "pyjwt (>=2.0)"]
+pyopenssl = ["cryptography (<39.0.0)", "cryptography (>=38.0.3)", "pyopenssl (>=20.0.0)"]
 reauth = ["pyu2f (>=0.1.5)"]
-requests = ["requests (>=2.20.0,<3.0.0.dev0)"]
+requests = ["requests (>=2.20.0,<3.0.0)"]
+testing = ["aiohttp (<3.10.0)", "aiohttp (>=3.6.2,<4.0.0)", "aioresponses", "cryptography (<39.0.0)", "cryptography (>=38.0.3)", "flask", "freezegun", "grpcio", "mock", "oauth2client", "packaging", "pyjwt (>=2.0)", "pyopenssl (<24.3.0)", "pyopenssl (>=20.0.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-localserver", "pyu2f (>=0.1.5)", "requests (>=2.20.0,<3.0.0)", "responses", "urllib3"]
+urllib3 = ["packaging", "urllib3"]
 
 [[package]]
 name = "h11"
@@ -826,14 +829,14 @@ files = [
 
 [[package]]
 name = "httpcore"
-version = "1.0.7"
+version = "1.0.8"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "integration"]
 files = [
-    {file = "httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd"},
-    {file = "httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c"},
+    {file = "httpcore-1.0.8-py3-none-any.whl", hash = "sha256:5254cf149bcb5f75e9d1b2b9f729ea4a4b883d1ad7379fc632b727cec23674be"},
+    {file = "httpcore-1.0.8.tar.gz", hash = "sha256:86e94505ed24ea06514883fd44d2bc02d90e77e7979c8eb71b90f41d364a1bad"},
 ]
 
 [package.dependencies]
@@ -936,14 +939,14 @@ tomli = {version = "*", markers = "python_version > \"3.6\" and python_version <
 
 [[package]]
 name = "ipython"
-version = "8.34.0"
+version = "8.35.0"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.10"
 groups = ["integration"]
 files = [
-    {file = "ipython-8.34.0-py3-none-any.whl", hash = "sha256:0419883fa46e0baa182c5d50ebb8d6b49df1889fdb70750ad6d8cfe678eda6e3"},
-    {file = "ipython-8.34.0.tar.gz", hash = "sha256:c31d658e754673ecc6514583e7dda8069e47136eb62458816b7d1e6625948b5a"},
+    {file = "ipython-8.35.0-py3-none-any.whl", hash = "sha256:e6b7470468ba6f1f0a7b116bb688a3ece2f13e2f94138e508201fad677a788ba"},
+    {file = "ipython-8.35.0.tar.gz", hash = "sha256:d200b7d93c3f5883fc36ab9ce28a18249c7706e51347681f80a0aef9895f2520"},
 ]
 
 [package.dependencies]
@@ -971,7 +974,7 @@ notebook = ["ipywidgets", "notebook"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
 test = ["packaging", "pickleshare", "pytest", "pytest-asyncio (<0.22)", "testpath"]
-test-extra = ["curio", "ipython[test]", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.23)", "pandas", "trio"]
+test-extra = ["curio", "ipython[test]", "jupyter_ai", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.23)", "pandas", "trio"]
 
 [[package]]
 name = "isodate"
@@ -1059,14 +1062,14 @@ format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-
 
 [[package]]
 name = "jsonschema-specifications"
-version = "2024.10.1"
+version = "2025.4.1"
 description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
 optional = false
 python-versions = ">=3.9"
 groups = ["charm-libs"]
 files = [
-    {file = "jsonschema_specifications-2024.10.1-py3-none-any.whl", hash = "sha256:a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf"},
-    {file = "jsonschema_specifications-2024.10.1.tar.gz", hash = "sha256:0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272"},
+    {file = "jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af"},
+    {file = "jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608"},
 ]
 
 [package.dependencies]
@@ -1270,14 +1273,14 @@ traitlets = "*"
 
 [[package]]
 name = "mypy-extensions"
-version = "1.0.0"
+version = "1.1.0"
 description = "Type system extensions for programs checked with the mypy type checker."
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.8"
 groups = ["format", "integration", "lint"]
 files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+    {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
+    {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
 ]
 
 [[package]]
@@ -1299,51 +1302,51 @@ signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "ops"
-version = "2.19.4"
+version = "2.20.0"
 description = "The Python library behind great charms"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "charm-libs", "unit"]
 files = [
-    {file = "ops-2.19.4-py3-none-any.whl", hash = "sha256:ca23c62441576e0e25a33eb8e3c6c3583b77c5954913f7a682b3b002b0858519"},
-    {file = "ops-2.19.4.tar.gz", hash = "sha256:3d6ef474341abaa86ef9ed7dc21e6292a1d690546ec830d4458d56f6eb4af350"},
+    {file = "ops-2.20.0-py3-none-any.whl", hash = "sha256:94791a4b45f00c6902494a4934480c85947880b27f5ebf3a0ec32e8cc6279c99"},
+    {file = "ops-2.20.0.tar.gz", hash = "sha256:be1dcfd0bb748839fbc200bbd073a6acf9648401c3729db22d8594ebb4301e05"},
 ]
 
 [package.dependencies]
-ops-scenario = {version = "7.19.4", optional = true, markers = "extra == \"testing\""}
+ops-scenario = {version = "7.20.0", optional = true, markers = "extra == \"testing\""}
 PyYAML = "==6.*"
 websocket-client = "==1.*"
 
 [package.extras]
 docs = ["canonical-sphinx-extensions", "furo", "linkify-it-py", "myst-parser", "pyspelling", "sphinx (>=8.0.0,<8.1.0)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-design", "sphinx-notfound-page", "sphinx-tabs", "sphinxcontrib-jquery", "sphinxext-opengraph"]
-testing = ["ops-scenario (==7.19.4)"]
+testing = ["ops-scenario (==7.20.0)"]
 
 [[package]]
 name = "ops-scenario"
-version = "7.19.4"
+version = "7.20.0"
 description = "Python library providing a state-transition testing API for Operator Framework charms."
 optional = false
 python-versions = ">=3.8"
 groups = ["unit"]
 files = [
-    {file = "ops_scenario-7.19.4-py3-none-any.whl", hash = "sha256:1168daa9a9c6f67806d2e74562e89585fc86b0d52c4b7ebb457e04dcfbe42099"},
-    {file = "ops_scenario-7.19.4.tar.gz", hash = "sha256:e33b1578bee513fce03fc2323e6f1f409fbff53e1e980aec1cb747f5463b2c57"},
+    {file = "ops_scenario-7.20.0-py3-none-any.whl", hash = "sha256:ee8defa368751d819e3b8ae08de672fa281af16274567f022c42a5f2c6c584a3"},
+    {file = "ops_scenario-7.20.0.tar.gz", hash = "sha256:f1c058dac51bb953389cbddedbf131fe545b9932ae8fe32c1e701833b31ea88b"},
 ]
 
 [package.dependencies]
-ops = "2.19.4"
+ops = "2.20.0"
 PyYAML = ">=6.0.1"
 
 [[package]]
 name = "packaging"
-version = "24.2"
+version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["integration", "unit"]
 files = [
-    {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
-    {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
+    {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
+    {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
 ]
 
 [[package]]
@@ -1459,14 +1462,14 @@ files = [
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.50"
+version = "3.0.51"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.8"
 groups = ["integration"]
 files = [
-    {file = "prompt_toolkit-3.0.50-py3-none-any.whl", hash = "sha256:9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198"},
-    {file = "prompt_toolkit-3.0.50.tar.gz", hash = "sha256:544748f3860a2623ca5cd6d2795e7a14f3d0e1c3c9728359013f79877fc89bab"},
+    {file = "prompt_toolkit-3.0.51-py3-none-any.whl", hash = "sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07"},
+    {file = "prompt_toolkit-3.0.51.tar.gz", hash = "sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed"},
 ]
 
 [package.dependencies]
@@ -1804,14 +1807,14 @@ testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy 
 
 [[package]]
 name = "pytest-operator"
-version = "0.41.0"
+version = "0.42.0"
 description = "Fixtures for Operators"
 optional = false
 python-versions = "*"
 groups = ["integration"]
 files = [
-    {file = "pytest_operator-0.41.0-py3-none-any.whl", hash = "sha256:03f4ff3dfb4b4468ad4491f42ad6e5ad5710a2b4d9d3350d75496bc73daf978b"},
-    {file = "pytest_operator-0.41.0.tar.gz", hash = "sha256:f12e507bdd69992f96c959a9f62d804c3438c77376a43623364abceddde62ac9"},
+    {file = "pytest_operator-0.42.0-py3-none-any.whl", hash = "sha256:29ee3df46b5a47b435f63f7efa2e1433807ba723ac3890f86b88033f79b3e48c"},
+    {file = "pytest_operator-0.42.0.tar.gz", hash = "sha256:389afb648dab91eb8f0e224cbe58f05598e850aafc46e589fce1705577309c69"},
 ]
 
 [package.dependencies]
@@ -2116,14 +2119,14 @@ files = [
 
 [[package]]
 name = "rsa"
-version = "4.9"
+version = "4.9.1"
 description = "Pure-Python RSA implementation"
 optional = false
-python-versions = ">=3.6,<4"
+python-versions = "<4,>=3.6"
 groups = ["integration"]
 files = [
-    {file = "rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"},
-    {file = "rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"},
+    {file = "rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762"},
+    {file = "rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75"},
 ]
 
 [package.dependencies]
@@ -2131,30 +2134,30 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "ruff"
-version = "0.11.2"
+version = "0.11.6"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["format", "lint"]
 files = [
-    {file = "ruff-0.11.2-py3-none-linux_armv6l.whl", hash = "sha256:c69e20ea49e973f3afec2c06376eb56045709f0212615c1adb0eda35e8a4e477"},
-    {file = "ruff-0.11.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2c5424cc1c4eb1d8ecabe6d4f1b70470b4f24a0c0171356290b1953ad8f0e272"},
-    {file = "ruff-0.11.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ecf20854cc73f42171eedb66f006a43d0a21bfb98a2523a809931cda569552d9"},
-    {file = "ruff-0.11.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c543bf65d5d27240321604cee0633a70c6c25c9a2f2492efa9f6d4b8e4199bb"},
-    {file = "ruff-0.11.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20967168cc21195db5830b9224be0e964cc9c8ecf3b5a9e3ce19876e8d3a96e3"},
-    {file = "ruff-0.11.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:955a9ce63483999d9f0b8f0b4a3ad669e53484232853054cc8b9d51ab4c5de74"},
-    {file = "ruff-0.11.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:86b3a27c38b8fce73bcd262b0de32e9a6801b76d52cdb3ae4c914515f0cef608"},
-    {file = "ruff-0.11.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3b66a03b248c9fcd9d64d445bafdf1589326bee6fc5c8e92d7562e58883e30f"},
-    {file = "ruff-0.11.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0397c2672db015be5aa3d4dac54c69aa012429097ff219392c018e21f5085147"},
-    {file = "ruff-0.11.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:869bcf3f9abf6457fbe39b5a37333aa4eecc52a3b99c98827ccc371a8e5b6f1b"},
-    {file = "ruff-0.11.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2a2b50ca35457ba785cd8c93ebbe529467594087b527a08d487cf0ee7b3087e9"},
-    {file = "ruff-0.11.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7c69c74bf53ddcfbc22e6eb2f31211df7f65054bfc1f72288fc71e5f82db3eab"},
-    {file = "ruff-0.11.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6e8fb75e14560f7cf53b15bbc55baf5ecbe373dd5f3aab96ff7aa7777edd7630"},
-    {file = "ruff-0.11.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:842a472d7b4d6f5924e9297aa38149e5dcb1e628773b70e6387ae2c97a63c58f"},
-    {file = "ruff-0.11.2-py3-none-win32.whl", hash = "sha256:aca01ccd0eb5eb7156b324cfaa088586f06a86d9e5314b0eb330cb48415097cc"},
-    {file = "ruff-0.11.2-py3-none-win_amd64.whl", hash = "sha256:3170150172a8f994136c0c66f494edf199a0bbea7a409f649e4bc8f4d7084080"},
-    {file = "ruff-0.11.2-py3-none-win_arm64.whl", hash = "sha256:52933095158ff328f4c77af3d74f0379e34fd52f175144cefc1b192e7ccd32b4"},
-    {file = "ruff-0.11.2.tar.gz", hash = "sha256:ec47591497d5a1050175bdf4e1a4e6272cddff7da88a2ad595e1e326041d8d94"},
+    {file = "ruff-0.11.6-py3-none-linux_armv6l.whl", hash = "sha256:d84dcbe74cf9356d1bdb4a78cf74fd47c740bf7bdeb7529068f69b08272239a1"},
+    {file = "ruff-0.11.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9bc583628e1096148011a5d51ff3c836f51899e61112e03e5f2b1573a9b726de"},
+    {file = "ruff-0.11.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f2959049faeb5ba5e3b378709e9d1bf0cab06528b306b9dd6ebd2a312127964a"},
+    {file = "ruff-0.11.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63c5d4e30d9d0de7fedbfb3e9e20d134b73a30c1e74b596f40f0629d5c28a193"},
+    {file = "ruff-0.11.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:26a4b9a4e1439f7d0a091c6763a100cef8fbdc10d68593df6f3cfa5abdd9246e"},
+    {file = "ruff-0.11.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5edf270223dd622218256569636dc3e708c2cb989242262fe378609eccf1308"},
+    {file = "ruff-0.11.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f55844e818206a9dd31ff27f91385afb538067e2dc0beb05f82c293ab84f7d55"},
+    {file = "ruff-0.11.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d8f782286c5ff562e4e00344f954b9320026d8e3fae2ba9e6948443fafd9ffc"},
+    {file = "ruff-0.11.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:01c63ba219514271cee955cd0adc26a4083df1956d57847978383b0e50ffd7d2"},
+    {file = "ruff-0.11.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15adac20ef2ca296dd3d8e2bedc6202ea6de81c091a74661c3666e5c4c223ff6"},
+    {file = "ruff-0.11.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4dd6b09e98144ad7aec026f5588e493c65057d1b387dd937d7787baa531d9bc2"},
+    {file = "ruff-0.11.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:45b2e1d6c0eed89c248d024ea95074d0e09988d8e7b1dad8d3ab9a67017a5b03"},
+    {file = "ruff-0.11.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:bd40de4115b2ec4850302f1a1d8067f42e70b4990b68838ccb9ccd9f110c5e8b"},
+    {file = "ruff-0.11.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:77cda2dfbac1ab73aef5e514c4cbfc4ec1fbef4b84a44c736cc26f61b3814cd9"},
+    {file = "ruff-0.11.6-py3-none-win32.whl", hash = "sha256:5151a871554be3036cd6e51d0ec6eef56334d74dfe1702de717a995ee3d5b287"},
+    {file = "ruff-0.11.6-py3-none-win_amd64.whl", hash = "sha256:cce85721d09c51f3b782c331b0abd07e9d7d5f775840379c640606d3159cae0e"},
+    {file = "ruff-0.11.6-py3-none-win_arm64.whl", hash = "sha256:3567ba0d07fb170b1b48d944715e3294b77f5b7679e8ba258199a250383ccb79"},
+    {file = "ruff-0.11.6.tar.gz", hash = "sha256:bec8bcc3ac228a45ccc811e45f7eb61b950dbf4cf31a67fa89352574b01c7d79"},
 ]
 
 [[package]]
@@ -2221,14 +2224,14 @@ spark8t = ">=0.0.10"
 
 [[package]]
 name = "spark8t"
-version = "0.0.11"
+version = "0.0.12"
 description = "This project provides some utilities function and CLI commands to run Spark on K8s."
 optional = false
-python-versions = "<4.0,>3.8"
+python-versions = "<4.0,>=3.10"
 groups = ["main", "integration"]
 files = [
-    {file = "spark8t-0.0.11-py3-none-any.whl", hash = "sha256:88a0215bb5807888baea5144f9d3fae7ab501556fab48fee97a9be60804e1b75"},
-    {file = "spark8t-0.0.11.tar.gz", hash = "sha256:631b1c60546cec2442d904f43b76cabefceb0872c48176187a36920e3bcfcf4d"},
+    {file = "spark8t-0.0.12-py3-none-any.whl", hash = "sha256:3de9318a13e4ba85f8d3ac32562121a9867dd2bf6a1057ed87e6832a95f63ef2"},
+    {file = "spark8t-0.0.12.tar.gz", hash = "sha256:4cd37c196850fccec480df1fc5e688415e692e5f7e625981f07a89a63d464b70"},
 ]
 
 [package.dependencies]
@@ -2381,14 +2384,14 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,
 
 [[package]]
 name = "typing-extensions"
-version = "4.13.0"
+version = "4.13.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "charm-libs", "integration"]
 files = [
-    {file = "typing_extensions-4.13.0-py3-none-any.whl", hash = "sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5"},
-    {file = "typing_extensions-4.13.0.tar.gz", hash = "sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b"},
+    {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
+    {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
 ]
 markers = {main = "python_version < \"3.13\""}
 
@@ -2410,14 +2413,14 @@ typing-extensions = ">=3.7.4"
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.4.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "integration"]
 files = [
-    {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
-    {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
+    {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
+    {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
 ]
 
 [package.extras]
@@ -2537,4 +2540,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "90ba35b5b529125a96b6cbe88d17e4b471cdd9fa0e8b1e037e03e008be5070e6"
+content-hash = "417ca7bae383ee6048325113649a6aed629c03e9b863a9990d865a7c1985b13e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1222,12 +1222,66 @@ files = [
 traitlets = "*"
 
 [[package]]
+name = "mypy"
+version = "1.15.0"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["lint"]
+files = [
+    {file = "mypy-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:979e4e1a006511dacf628e36fadfecbcc0160a8af6ca7dad2f5025529e082c13"},
+    {file = "mypy-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c4bb0e1bd29f7d34efcccd71cf733580191e9a264a2202b0239da95984c5b559"},
+    {file = "mypy-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be68172e9fd9ad8fb876c6389f16d1c1b5f100ffa779f77b1fb2176fcc9ab95b"},
+    {file = "mypy-1.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7be1e46525adfa0d97681432ee9fcd61a3964c2446795714699a998d193f1a3"},
+    {file = "mypy-1.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2e2c2e6d3593f6451b18588848e66260ff62ccca522dd231cd4dd59b0160668b"},
+    {file = "mypy-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:6983aae8b2f653e098edb77f893f7b6aca69f6cffb19b2cc7443f23cce5f4828"},
+    {file = "mypy-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2922d42e16d6de288022e5ca321cd0618b238cfc5570e0263e5ba0a77dbef56f"},
+    {file = "mypy-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ee2d57e01a7c35de00f4634ba1bbf015185b219e4dc5909e281016df43f5ee5"},
+    {file = "mypy-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973500e0774b85d9689715feeffcc980193086551110fd678ebe1f4342fb7c5e"},
+    {file = "mypy-1.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a95fb17c13e29d2d5195869262f8125dfdb5c134dc8d9a9d0aecf7525b10c2c"},
+    {file = "mypy-1.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1905f494bfd7d85a23a88c5d97840888a7bd516545fc5aaedff0267e0bb54e2f"},
+    {file = "mypy-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:c9817fa23833ff189db061e6d2eff49b2f3b6ed9856b4a0a73046e41932d744f"},
+    {file = "mypy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aea39e0583d05124836ea645f412e88a5c7d0fd77a6d694b60d9b6b2d9f184fd"},
+    {file = "mypy-1.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f2147ab812b75e5b5499b01ade1f4a81489a147c01585cda36019102538615f"},
+    {file = "mypy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce436f4c6d218a070048ed6a44c0bbb10cd2cc5e272b29e7845f6a2f57ee4464"},
+    {file = "mypy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8023ff13985661b50a5928fc7a5ca15f3d1affb41e5f0a9952cb68ef090b31ee"},
+    {file = "mypy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e"},
+    {file = "mypy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22"},
+    {file = "mypy-1.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93faf3fdb04768d44bf28693293f3904bbb555d076b781ad2530214ee53e3445"},
+    {file = "mypy-1.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:811aeccadfb730024c5d3e326b2fbe9249bb7413553f15499a4050f7c30e801d"},
+    {file = "mypy-1.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98b7b9b9aedb65fe628c62a6dc57f6d5088ef2dfca37903a7d9ee374d03acca5"},
+    {file = "mypy-1.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c43a7682e24b4f576d93072216bf56eeff70d9140241f9edec0c104d0c515036"},
+    {file = "mypy-1.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:baefc32840a9f00babd83251560e0ae1573e2f9d1b067719479bfb0e987c6357"},
+    {file = "mypy-1.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b9378e2c00146c44793c98b8d5a61039a048e31f429fb0eb546d93f4b000bedf"},
+    {file = "mypy-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e601a7fa172c2131bff456bb3ee08a88360760d0d2f8cbd7a75a65497e2df078"},
+    {file = "mypy-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:712e962a6357634fef20412699a3655c610110e01cdaa6180acec7fc9f8513ba"},
+    {file = "mypy-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f95579473af29ab73a10bada2f9722856792a36ec5af5399b653aa28360290a5"},
+    {file = "mypy-1.15.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f8722560a14cde92fdb1e31597760dc35f9f5524cce17836c0d22841830fd5b"},
+    {file = "mypy-1.15.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1fbb8da62dc352133d7d7ca90ed2fb0e9d42bb1a32724c287d3c76c58cbaa9c2"},
+    {file = "mypy-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:d10d994b41fb3497719bbf866f227b3489048ea4bbbb5015357db306249f7980"},
+    {file = "mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e"},
+    {file = "mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43"},
+]
+
+[package.dependencies]
+mypy_extensions = ">=1.0.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing_extensions = ">=4.6.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+faster-cache = ["orjson"]
+install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
+reports = ["lxml"]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 description = "Type system extensions for programs checked with the mypy type checker."
 optional = false
 python-versions = ">=3.8"
-groups = ["integration"]
+groups = ["integration", "lint"]
 files = [
     {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
     {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
@@ -2218,8 +2272,7 @@ version = "2.2.1"
 description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
-groups = ["integration", "unit"]
-markers = "python_full_version <= \"3.11.0a6\""
+groups = ["integration", "lint", "unit"]
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
     {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
@@ -2254,6 +2307,7 @@ files = [
     {file = "tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"},
     {file = "tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"},
 ]
+markers = {integration = "python_full_version <= \"3.11.0a6\"", lint = "python_version < \"3.11\"", unit = "python_full_version <= \"3.11.0a6\""}
 
 [[package]]
 name = "toposort"
@@ -2284,12 +2338,24 @@ docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,<8.2)", "pytest-mock", "pytest-mypy-testing"]
 
 [[package]]
+name = "types-psycopg2"
+version = "2.9.21.20250318"
+description = "Typing stubs for psycopg2"
+optional = false
+python-versions = ">=3.9"
+groups = ["lint"]
+files = [
+    {file = "types_psycopg2-2.9.21.20250318-py3-none-any.whl", hash = "sha256:7296d111ad950bbd2fc979a1ab0572acae69047f922280e77db657c00d2c79c0"},
+    {file = "types_psycopg2-2.9.21.20250318.tar.gz", hash = "sha256:eb6eac5bfb16adfd5f16b818918b9e26a40ede147e0f2bbffdf53a6ef7025a87"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.13.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "charm-libs", "integration"]
+groups = ["main", "charm-libs", "integration", "lint"]
 files = [
     {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
     {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
@@ -2441,4 +2507,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "d58f32b0de4f7188b1dca9dce0c92ee1cbe7ac90e4e1d0d7cae27c87594eea83"
+content-hash = "b02eef5a45eb0f07bc6416e6bcc9b192bd5179bb1adb0c7a09f450dbad1ba3f0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2540,4 +2540,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "417ca7bae383ee6048325113649a6aed629c03e9b863a9990d865a7c1985b13e"
+content-hash = "23b184b1235fbdc9d16ef72ece1ac496b802724b9d2cf609e8bdd4d0e6624f29"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1747,26 +1747,6 @@ pytest-asyncio = "<0.23"
 pyyaml = "*"
 
 [[package]]
-name = "pytest-operator-cache"
-version = "0.1.0"
-description = ""
-optional = false
-python-versions = "^3.8"
-groups = ["integration"]
-files = []
-develop = false
-
-[package.dependencies]
-pyyaml = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/canonical/data-platform-workflows"
-reference = "v24.0.5"
-resolved_reference = "078fb649213bbffe223e826f04560c2e9c9c3396"
-subdirectory = "python/pytest_plugins/pytest_operator_cache"
-
-[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2461,4 +2441,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "879c1f441100ec4bdfcc43d3f2aef32dabd13d38e899797c47db4d31d9459a60"
+content-hash = "d58f32b0de4f7188b1dca9dce0c92ee1cbe7ac90e4e1d0d7cae27c87594eea83"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ package-mode = false
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
 ops = ">=2.4.1"
-boto3 = "^1.26.75"
+# NOTE(boto): 1.36+ incompatible with minio because of MD5 checksum
+boto3 = ">=1.28.0,<1.36"
 lightkube = "^0.15.2"
 psycopg2 = "^2.9.9"
 tenacity = ">=8.0.1"
@@ -86,7 +87,6 @@ boto3 = ">=1.28.0,<1.36"
 tenacity = "^8.2.2"
 spark-k8s-test = "^0.0.2"
 pytest-operator-cache = { git = "https://github.com/canonical/data-platform-workflows", tag = "v24.0.5", subdirectory = "python/pytest_plugins/pytest_operator_cache" }
-
 
 [tool.ruff]
 line-length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
-ops = ">=2.4.1"
+ops = "^2.17.0"
 # NOTE(boto): 1.36+ incompatible with minio because of MD5 checksum
 boto3 = ">=1.28.0,<1.36"
 lightkube = "^0.15.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,5 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-
-# Testing tools configuration
-[tool.coverage.run]
-branch = true
-
-[tool.coverage.report]
-show_missing = true
-
-[tool.pytest.ini_options]
-minversion = "6.0"
-log_cli_level = "INFO"
-asyncio_mode = "auto"
-markers = ["unstable"]
-
-# Formatting tools configuration
-[tool.black]
-line-length = 99
-target-version = ["py310"]
-
 [tool.poetry]
 name = "kyuubi-k8s-operator"
 version = "1.0"
@@ -54,15 +35,13 @@ jsonschema = "*"
 optional = true
 
 [tool.poetry.group.format.dependencies]
-black = "^22.3.0"
-ruff = ">=0.0.157"
+ruff = ">=0.10.0"
 
 [tool.poetry.group.lint]
 optional = true
 
 [tool.poetry.group.lint.dependencies]
-black = "^22.3.0"
-ruff = ">=0.0.157"
+ruff = ">=0.10.0"
 codespell = ">=2.2.2"
 
 [tool.poetry.group.unit]
@@ -113,6 +92,19 @@ extend-ignore = [
   "D413",
 ]
 mccabe.max-complexity = 10
+
+# Testing tools configuration
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+log_cli_level = "INFO"
+asyncio_mode = "auto"
+markers = ["unstable"]
 
 [tool.pyright]
 include = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ optional = true
 [tool.poetry.group.lint.dependencies]
 ruff = ">=0.10.0"
 codespell = ">=2.2.2"
+mypy = "^1.15.0"
+types-psycopg2 = "^2.9.21.20250318"
 
 [tool.poetry.group.unit]
 optional = true
@@ -75,7 +77,7 @@ src = ["src", "tests"]
 [tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "D", "I001"]
 ignore = ["E501", "D107"]
-per-file-ignores = { "tests/*" = ["D100", "D101", "D102", "D103", "D104", "E999"], "src/literals.py" = ["D101"] }
+per-file-ignores = { "tests/*" = ["D100", "D101", "D102", "D103", "D104", "E999"], "src/literals.py" = ["D101"], "src/*/__init__.py" = ["D104"] }
 extend-ignore = [
   "D203",
   "D204",
@@ -91,6 +93,18 @@ extend-ignore = [
   "D413",
 ]
 mccabe.max-complexity = 10
+
+[tool.mypy]
+[[tool.mypy.overrides]]
+module = [
+  "charms.data_platform_libs.*",
+  "charms.grafana_k8s.*",
+  "charms.loki_k8s.*",
+  "charms.prometheus_k8s.*",
+  "charms.tls_certificates_interface.*",
+  "spark8t.services"
+]
+ignore_missing_imports = true
 
 # Testing tools configuration
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ pytest-operator = ">0.20"
 boto3 = ">=1.28.0,<1.36"
 tenacity = "^8.2.2"
 spark-k8s-test = "^0.0.2"
-pytest-operator-cache = { git = "https://github.com/canonical/data-platform-workflows", tag = "v24.0.5", subdirectory = "python/pytest_plugins/pytest_operator_cache" }
 
 [tool.ruff]
 line-length = 99

--- a/src/charm.py
+++ b/src/charm.py
@@ -62,7 +62,12 @@ class KyuubiCharm(TypedCharmBase[CharmConfig]):
         self.auth_events = AuthenticationEvents(self, self.context, self.workload)
         self.zookeeper_events = ZookeeperEvents(self, self.context, self.workload)
         self.action_events = ActionEvents(self, self.context, self.workload)
-        self.upgrade_events = UpgradeEvents(self, self.context, self.workload, KyuubiDependencyModel(**DEPENDENCIES))  # type: ignore
+        self.upgrade_events = UpgradeEvents(
+            self,
+            self.context,
+            self.workload,
+            KyuubiDependencyModel(**DEPENDENCIES),  # type: ignore
+        )
         self.tls_events = TLSEvents(self, self.context, self.workload)
         self.provider_events = KyuubiClientProviderEvents(self, self.context, self.workload)
 

--- a/src/config/hive.py
+++ b/src/config/hive.py
@@ -22,10 +22,11 @@ class HiveConfig(WithLogging):
         self.db_info = db_info
 
     def _get_db_connection_url(self) -> str:
-        endpoint = self.db_info.endpoint
-        return (
-            f"jdbc:postgresql://{endpoint}/{METASTORE_DATABASE_NAME}?createDatabaseIfNotExist=true"
-        )
+        match self.db_info:
+            case None:
+                return ""
+            case db:
+                return f"jdbc:postgresql://{db.endpoint}/{METASTORE_DATABASE_NAME}?createDatabaseIfNotExist=true"
 
     @property
     def _db_conf(self) -> dict[str, str]:

--- a/src/config/kyuubi.py
+++ b/src/config/kyuubi.py
@@ -26,8 +26,11 @@ class KyuubiConfig(WithLogging):
         self.keystore_path = keystore_path
 
     def _get_db_connection_url(self) -> str:
-        endpoint = self.db_info.endpoint
-        return f"jdbc:postgresql://{endpoint}/{self.db_info.dbname}"
+        match self.db_info:
+            case None:
+                return ""
+            case db:
+                return f"jdbc:postgresql://{db.endpoint}/{db.dbname}"
 
     def _get_authentication_query(self) -> str:
         return (

--- a/src/constants.py
+++ b/src/constants.py
@@ -49,4 +49,4 @@ DEPENDENCIES = {
     },
 }
 
-SECRETS_APP = []
+SECRETS_APP: list[str] = []

--- a/src/core/domain.py
+++ b/src/core/domain.py
@@ -82,7 +82,7 @@ class StateBase:
         """Clean the content of the relation data."""
         if not self.relation:
             return
-        self.relation.data[self.component] = {}
+        self.relation.data[self.component] = {}  # type: ignore
 
 
 @dataclass
@@ -323,7 +323,7 @@ class KyuubiServer(RelationState):
     def external_address(self) -> Endpoint | None:
         """The external address for the unit, for external communication."""
         return self.k8s.get_service_endpoint(
-            expose_external=self.unit._backend.config_get().get("expose-external")
+            expose_external=str(self.unit._backend.config_get().get("expose-external"))
         )
 
     @property

--- a/src/core/domain.py
+++ b/src/core/domain.py
@@ -38,6 +38,7 @@ class Status(Enum):
     WAITING_PEBBLE = MaintenanceStatus("Waiting for Pebble")
     MISSING_OBJECT_STORAGE_BACKEND = BlockedStatus("Missing Object Storage backend")
     MISSING_INTEGRATION_HUB = BlockedStatus("Missing integration hub relation")
+    MISSING_AUTH_DB = BlockedStatus("Missing authentication database relation")
     INVALID_NAMESPACE = BlockedStatus("Invalid config option: namespace")
     INVALID_SERVICE_ACCOUNT = BlockedStatus("Invalid config option: service-account")
     INSUFFICIENT_CLUSTER_PERMISSIONS = BlockedStatus(

--- a/src/events/auth.py
+++ b/src/events/auth.py
@@ -85,5 +85,5 @@ class AuthenticationEvents(BaseEventHandler, WithLogging):
         """
         self.logger.info("Authentication database relation departed")
         # TODO: I don't think we should be doing this, is it our responsibility?
-        auth = AuthenticationManager(cast(DatabaseConnectionInfo, self.context.auth_db))
-        auth.remove_auth_db()
+        # auth = AuthenticationManager(cast(DatabaseConnectionInfo, self.context.auth_db))
+        # auth.remove_auth_db()

--- a/src/events/auth.py
+++ b/src/events/auth.py
@@ -4,24 +4,31 @@
 
 """Authentication related event handlers."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseCreatedEvent,
     DatabaseRequirerEventHandlers,
 )
-from ops import CharmBase
 
 from core.context import Context
-from core.workload import KyuubiWorkloadBase
+from core.domain import DatabaseConnectionInfo
+from core.workload.kyuubi import KyuubiWorkload
 from events.base import BaseEventHandler, compute_status, defer_when_not_ready
 from managers.auth import AuthenticationManager
 from managers.kyuubi import KyuubiManager
 from utils.logging import WithLogging
 
+if TYPE_CHECKING:
+    from charm import KyuubiCharm
+
 
 class AuthenticationEvents(BaseEventHandler, WithLogging):
     """Class implementing PostgreSQL metastore event hooks."""
 
-    def __init__(self, charm: CharmBase, context: Context, workload: KyuubiWorkloadBase):
+    def __init__(self, charm: KyuubiCharm, context: Context, workload: KyuubiWorkload) -> None:
         super().__init__(charm, "s3")
 
         self.charm = charm
@@ -48,8 +55,12 @@ class AuthenticationEvents(BaseEventHandler, WithLogging):
     @defer_when_not_ready
     def _on_auth_db_created(self, event: DatabaseCreatedEvent) -> None:
         """Handle the event when authentication database is created."""
+        if not (auth_db := self.context.auth_db) or auth_db is None:
+            event.defer()
+            return
+
         self.logger.info("Authentication database created...")
-        auth = AuthenticationManager(self.context.auth_db)
+        auth = AuthenticationManager(auth_db)
         auth.prepare_auth_db()
         self.kyuubi.update()
 
@@ -73,5 +84,6 @@ class AuthenticationEvents(BaseEventHandler, WithLogging):
         can be fetched for one last time in order to remove authentication database.
         """
         self.logger.info("Authentication database relation departed")
-        auth = AuthenticationManager(self.context.auth_db)
+        # TODO: I don't think we should be doing this, is it our responsibility?
+        auth = AuthenticationManager(cast(DatabaseConnectionInfo, self.context.auth_db))
         auth.remove_auth_db()

--- a/src/events/auth.py
+++ b/src/events/auth.py
@@ -78,12 +78,5 @@ class AuthenticationEvents(BaseEventHandler, WithLogging):
 
     @compute_status
     def _on_auth_db_relation_departed(self, event) -> None:
-        """Handle the event when the authentication database relation is departed.
-
-        Until this point, the relation data is still there and hence the credentials
-        can be fetched for one last time in order to remove authentication database.
-        """
+        """Handle the event when the authentication database relation is departed."""
         self.logger.info("Authentication database relation departed")
-        # TODO: I don't think we should be doing this, is it our responsibility?
-        # auth = AuthenticationManager(cast(DatabaseConnectionInfo, self.context.auth_db))
-        # auth.remove_auth_db()

--- a/src/events/base.py
+++ b/src/events/base.py
@@ -13,7 +13,7 @@ from ops import EventBase, Object, StatusBase
 
 from core.context import Context
 from core.domain import Status
-from core.workload import KyuubiWorkloadBase
+from core.workload.kyuubi import KyuubiWorkload
 from managers.hive_metastore import HiveMetastoreManager
 from managers.k8s import K8sManager
 from managers.service import ServiceManager
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 class BaseEventHandler(Object, WithLogging):
     """Base class for all Event Handler classes in the Spark Integration Hub."""
 
-    workload: KyuubiWorkloadBase
+    workload: KyuubiWorkload
     charm: KyuubiCharm
     context: Context
 
@@ -84,7 +84,7 @@ class BaseEventHandler(Object, WithLogging):
 
 
 def compute_status(
-    hook: Callable[[BaseEventHandler, EventBase], None],
+    hook: Callable,
 ) -> Callable[[BaseEventHandler, EventBase], None]:
     """Decorator to automatically compute statuses at the end of the hook."""
 
@@ -101,7 +101,7 @@ def compute_status(
 
 
 def defer_when_not_ready(
-    hook: Callable[[BaseEventHandler, EventBase], None],
+    hook: Callable,
 ) -> Callable[[BaseEventHandler, EventBase], None]:
     """Decorator to defer hook is workload is not ready."""
 

--- a/src/events/base.py
+++ b/src/events/base.py
@@ -59,6 +59,9 @@ class BaseEventHandler(Object, WithLogging):
         if not k8s_manager.is_service_account_valid():
             return Status.INVALID_SERVICE_ACCOUNT.value
 
+        if not self.context.auth_db:
+            return Status.MISSING_AUTH_DB.value
+
         metastore_manager = HiveMetastoreManager(self.workload)
         if self.context.metastore_db and not metastore_manager.is_metastore_valid():
             return Status.INVALID_METASTORE_SCHEMA.value

--- a/src/events/integration_hub.py
+++ b/src/events/integration_hub.py
@@ -4,7 +4,9 @@
 
 """Integration Hub related event handlers."""
 
-from ops import CharmBase
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from common.relation.spark_sa import (
     ServiceAccountGoneEvent,
@@ -13,16 +15,19 @@ from common.relation.spark_sa import (
     SparkServiceAccountRequirerEventHandlers,
 )
 from core.context import Context
-from core.workload import KyuubiWorkloadBase
+from core.workload.kyuubi import KyuubiWorkload
 from events.base import BaseEventHandler, compute_status, defer_when_not_ready
 from managers.kyuubi import KyuubiManager
 from utils.logging import WithLogging
+
+if TYPE_CHECKING:
+    from charm import KyuubiCharm
 
 
 class SparkIntegrationHubEvents(BaseEventHandler, WithLogging):
     """Class implementing Integration Hub event hooks."""
 
-    def __init__(self, charm: CharmBase, context: Context, workload: KyuubiWorkloadBase):
+    def __init__(self, charm: KyuubiCharm, context: Context, workload: KyuubiWorkload) -> None:
         super().__init__(charm, "integration-hub")
 
         self.charm = charm

--- a/src/events/kyuubi.py
+++ b/src/events/kyuubi.py
@@ -4,26 +4,31 @@
 
 """Kyuubi related event handlers."""
 
+from __future__ import annotations
+
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import ops
-from charms.data_platform_libs.v0.data_models import TypedCharmBase
 from ops import SecretChangedEvent
 
 from constants import PEER_REL
 from core.context import Context
-from core.workload import KyuubiWorkloadBase
+from core.workload.kyuubi import KyuubiWorkload
 from events.base import BaseEventHandler, compute_status, defer_when_not_ready
 from managers.kyuubi import KyuubiManager
 from managers.service import ServiceManager
 from managers.tls import TLSManager
 from utils.logging import WithLogging
 
+if TYPE_CHECKING:
+    from charm import KyuubiCharm
+
 
 class KyuubiEvents(BaseEventHandler, WithLogging):
     """Class implementing Kyuubi related event hooks."""
 
-    def __init__(self, charm: TypedCharmBase, context: Context, workload: KyuubiWorkloadBase):
+    def __init__(self, charm: KyuubiCharm, context: Context, workload: KyuubiWorkload) -> None:
         super().__init__(charm, "kyuubi")
 
         self.charm = charm
@@ -160,7 +165,8 @@ class KyuubiEvents(BaseEventHandler, WithLogging):
         if event.secret.label == self.context.cluster.data_interface._generate_secret_label(
             PEER_REL,
             self.context.cluster.relation.id,
-            "extra",  # type:ignore noqa  -- Changes with the https://github.com/canonical/data-platform-libs/issues/124
+            "extra",  # type: ignore
+            # Changes with the https://github.com/canonical/data-platform-libs/issues/124
         ):
             self.logger.info(f"Event secret label: {event.secret.label} updated!")
 

--- a/src/events/kyuubi.py
+++ b/src/events/kyuubi.py
@@ -103,7 +103,7 @@ class KyuubiEvents(BaseEventHandler, WithLogging):
         if sans_ip_changed or sans_dns_changed:
             self.logger.info(
                 (
-                    f'SERVER {self.charm.unit.name.split("/")[1]} updating certificate SANs - '
+                    f"SERVER {self.charm.unit.name.split('/')[1]} updating certificate SANs - "
                     f"OLD SANs IP = {current_sans_ip - expected_sans_ip}, "
                     f"NEW SANs IP = {expected_sans_ip - current_sans_ip}, "
                     f"OLD SANs DNS = {current_sans_dns - expected_sans_dns}, "

--- a/src/events/metastore.py
+++ b/src/events/metastore.py
@@ -4,25 +4,31 @@
 
 """Metastore database related event handlers."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseCreatedEvent,
     DatabaseRequirerEventHandlers,
 )
-from ops import CharmBase
 
 from constants import HIVE_SCHEMA_VERSION
 from core.context import Context
-from core.workload import KyuubiWorkloadBase
+from core.workload.kyuubi import KyuubiWorkload
 from events.base import BaseEventHandler, compute_status, defer_when_not_ready
 from managers.hive_metastore import HiveMetastoreManager
 from managers.kyuubi import KyuubiManager
 from utils.logging import WithLogging
 
+if TYPE_CHECKING:
+    from charm import KyuubiCharm
+
 
 class MetastoreEvents(BaseEventHandler, WithLogging):
     """Class implementing PostgreSQL metastore event hooks."""
 
-    def __init__(self, charm: CharmBase, context: Context, workload: KyuubiWorkloadBase):
+    def __init__(self, charm: KyuubiCharm, context: Context, workload: KyuubiWorkload) -> None:
         super().__init__(charm, "metastore")
 
         self.charm = charm

--- a/src/events/zookeeper.py
+++ b/src/events/zookeeper.py
@@ -4,22 +4,28 @@
 
 """Zookeeper related event handlers."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequirerEventHandlers
-from ops import CharmBase
 from ops.charm import RelationBrokenEvent, RelationChangedEvent
 
 from constants import ZOOKEEPER_REL
 from core.context import Context
-from core.workload import KyuubiWorkloadBase
+from core.workload.kyuubi import KyuubiWorkload
 from events.base import BaseEventHandler, compute_status
 from managers.kyuubi import KyuubiManager
 from utils.logging import WithLogging
+
+if TYPE_CHECKING:
+    from charm import KyuubiCharm
 
 
 class ZookeeperEvents(BaseEventHandler, WithLogging):
     """Class implementing Zookeeper integration event hooks."""
 
-    def __init__(self, charm: CharmBase, context: Context, workload: KyuubiWorkloadBase):
+    def __init__(self, charm: KyuubiCharm, context: Context, workload: KyuubiWorkload) -> None:
         super().__init__(charm, "zookeeper")
 
         self.charm = charm

--- a/src/managers/auth.py
+++ b/src/managers/auth.py
@@ -22,7 +22,7 @@ class AuthenticationManager(WithLogging):
     DEFAULT_ADMIN_USERNAME = "admin"
     AUTHENTICATION_TABLE_NAME = "kyuubi_users"
 
-    def __init__(self, db_info: DatabaseConnectionInfo = None) -> None:
+    def __init__(self, db_info: DatabaseConnectionInfo) -> None:
         super().__init__()
         self.database = DatabaseManager(db_info=db_info)
 
@@ -86,7 +86,7 @@ class AuthenticationManager(WithLogging):
         password = results[0][0]
         return password
 
-    def set_password(self, username: str, password: str) -> str:
+    def set_password(self, username: str, password: str) -> None:
         """Set a new password for the given username."""
         query = f"UPDATE {self.AUTHENTICATION_TABLE_NAME} SET passwd = %s WHERE username = %s"
         vars = (

--- a/src/managers/database.py
+++ b/src/managers/database.py
@@ -5,7 +5,6 @@
 
 """Database connection manager."""
 
-
 import psycopg2
 
 from constants import (

--- a/src/managers/database.py
+++ b/src/managers/database.py
@@ -17,10 +17,10 @@ from utils.logging import WithLogging
 class DatabaseManager(WithLogging):
     """Manager class encapsulating various database operations."""
 
-    def __init__(self, db_info: DatabaseConnectionInfo):
+    def __init__(self, db_info: DatabaseConnectionInfo) -> None:
         self.db_info = db_info
 
-    def execute(self, query: str, vars=None, dbname: str = None) -> tuple[bool, list]:
+    def execute(self, query: str, vars=None, dbname: str | None = None) -> tuple[bool, list]:
         """Execute a SQL query by connecting to a given database.
 
         Args:

--- a/src/managers/kyuubi.py
+++ b/src/managers/kyuubi.py
@@ -48,13 +48,19 @@ class KyuubiManager(WithLogging):
         set_zookeeper_none: bool = False,
         set_tls_none: bool = False,
         force_restart: bool = False,
-    ):
+    ) -> None:
         """Update Kyuubi service and restart it."""
         metastore_db_info = None if set_metastore_db_none else self.context.metastore_db
         auth_db_info = None if set_auth_db_none else self.context.auth_db
         service_account_info = None if set_service_account_none else self.context.service_account
         zookeeper_info = None if set_zookeeper_none else self.context.zookeeper
         tls_info = None if set_tls_none else self.context.tls
+
+        # auth is mandatory
+        if not auth_db_info:
+            self.logger.info("Workload stopped because auth db is missing.")
+            self.workload.stop()
+            return
 
         # Restart workload only if some configuration has changed.
         if any(

--- a/src/managers/kyuubi.py
+++ b/src/managers/kyuubi.py
@@ -59,7 +59,11 @@ class KyuubiManager(WithLogging):
         # auth is mandatory
         if not auth_db_info:
             self.logger.info("Workload stopped because auth db is missing.")
-            self.workload.stop()
+            try:
+                self.workload.stop()
+            except Exception:
+                # Stopping on best effort basis for now
+                pass
             return
 
         # Restart workload only if some configuration has changed.

--- a/src/managers/service.py
+++ b/src/managers/service.py
@@ -28,6 +28,9 @@ class Endpoint:
     host: str
     port: int
 
+    def __str__(self) -> str:  # noqa: D105
+        return f"{self.host}:{self.port}"
+
 
 class DNSEndpoint(Endpoint):
     """DNS endpoint type."""

--- a/src/managers/service.py
+++ b/src/managers/service.py
@@ -98,7 +98,7 @@ class ServiceManager(WithLogging):
     @functools.cache
     def get_node(self, unit_name: str) -> Node:
         """Return the node for the provided unit name."""
-        node_name = self.get_pod(unit_name).spec.nodeName
+        node_name: str = self.get_pod(unit_name).spec.nodeName  # type: ignore
         return self.lightkube_agent.get(
             res=Node,
             name=node_name,
@@ -221,8 +221,9 @@ class ServiceManager(WithLogging):
         }[expose_external]
 
         existing_service = self.get_service()
+
         if existing_service is not None:
-            if _ServiceType(existing_service.spec.type) == desired_service_type:
+            if _ServiceType(existing_service.spec.type) == desired_service_type:  # type: ignore
                 self.logger.info(
                     f"Kyuubi is already exposed on a service of type {desired_service_type}."
                 )
@@ -233,7 +234,8 @@ class ServiceManager(WithLogging):
         pod0 = self.get_pod(f"{self.app_name}/0")
 
         self.create_service(
-            service_type=desired_service_type, owner_references=pod0.metadata.ownerReferences
+            service_type=desired_service_type,
+            owner_references=pod0.metadata.ownerReferences,  # type: ignore
         )
 
     def get_node_ip(self, pod_name: str) -> str:

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -12,7 +12,6 @@ develop a new k8s charm using the Operator Framework:
 https://juju.is/docs/sdk/create-a-minimal-kubernetes-charm
 """
 
-
 import logging
 
 import ops

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -120,7 +120,7 @@ def charm_versions() -> IntegrationTestsCharms:
                 "revision": 70,
                 "series": "jammy",
                 "alias": "zookeeper",
-                "num_units": 3,
+                "num_units": 1,
             }
         ),
         tls=TestCharm(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -222,7 +222,19 @@ def test_pod(ops_test):
 
 
 @pytest.fixture(scope="module")
-async def kyuubi_charm(ops_test):
-    logger.info("Building charm...")
-    charm = await ops_test.build_charm(".")
-    return charm
+def kyuubi_charm() -> Path:
+    """Path to the packed integration hub charm."""
+    if not (path := next(iter(Path.cwd().glob("*.charm")), None)):
+        raise FileNotFoundError("Could not find packed kyuubi charm.")
+
+    return path
+
+
+@pytest.fixture(scope="module")
+def test_charm() -> Path:
+    if not (
+        path := next(iter((Path.cwd() / "tests/integration/app-charm").glob("*.charm")), None)
+    ):
+        raise FileNotFoundError("Could not find packed test charm.")
+
+    return path

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -65,6 +65,7 @@ class TestCharm(BaseModel):
 class IntegrationTestsCharms(BaseModel):
     s3: TestCharm
     postgres: TestCharm
+    auth_db: TestCharm
     integration_hub: TestCharm
     zookeeper: TestCharm
     tls: TestCharm
@@ -89,6 +90,16 @@ def charm_versions() -> IntegrationTestsCharms:
                 "revision": 281,
                 "series": "jammy",
                 "alias": "postgresql",
+                "trust": True,
+            }
+        ),
+        auth_db=TestCharm(
+            **{
+                "name": "postgresql-k8s",
+                "channel": "14/stable",
+                "revision": 281,
+                "series": "jammy",
+                "alias": "auth-db",
                 "trust": True,
             }
         ),

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -223,7 +223,9 @@ async def kill_kyuubi_process(ops_test, unit, kyuubi_pid):
     assert process.returncode == 0, f"Could not kill Kyuubi process with pid {kyuubi_pid}."
 
 
-async def is_entire_cluster_responding_requests(ops_test: OpsTest, test_pod) -> bool:
+async def is_entire_cluster_responding_requests(
+    ops_test: OpsTest, test_pod, username, password
+) -> bool:
     """Return whether the entire Kyuubi cluster is responding to requests from client."""
     jdbc_endpoint = await fetch_jdbc_endpoint(ops_test)
 
@@ -241,7 +243,17 @@ async def is_entire_cluster_responding_requests(ops_test: OpsTest, test_pod) -> 
         logger.info(f"Trying the {tries + 1}-th connection to see if entire cluster responds...")
         unique_id = get_random_name()
         query = f"SELECT '{unique_id}'"
-        pod_command = ["/opt/kyuubi/bin/beeline", "-u", jdbc_endpoint, "-e", query]
+        pod_command = [
+            "/opt/kyuubi/bin/beeline",
+            "-u",
+            jdbc_endpoint,
+            "-n",
+            username,
+            "-p",
+            password,
+            "-e",
+            query,
+        ]
         kubectl_command = [
             "kubectl",
             "exec",

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -72,7 +72,9 @@ async def fetch_jdbc_endpoint(ops_test):
     return jdbc_endpoint
 
 
-async def run_sql_test_against_jdbc_endpoint(ops_test: OpsTest, test_pod, jdbc_endpoint=None):
+async def run_sql_test_against_jdbc_endpoint(
+    ops_test: OpsTest, test_pod, username, password, jdbc_endpoint=None
+):
     """Verify the JDBC endpoint exposed by the charm with some SQL queries."""
     if jdbc_endpoint is None:
         jdbc_endpoint = await fetch_jdbc_endpoint(ops_test)
@@ -90,6 +92,8 @@ async def run_sql_test_against_jdbc_endpoint(ops_test: OpsTest, test_pod, jdbc_e
             jdbc_endpoint,
             get_random_name(),
             get_random_name(),
+            username,
+            password,
         ],
         capture_output=True,
     )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -188,9 +188,9 @@ async def get_kyuubi_pid(ops_test: OpsTest, unit):
         "aux",
     ]
     process = subprocess.run(command, capture_output=True, check=True)
-    assert (
-        process.returncode == 0
-    ), f"Command: {command} returned with return code {process.returncode}"
+    assert process.returncode == 0, (
+        f"Command: {command} returned with return code {process.returncode}"
+    )
 
     for line in process.stdout.decode().splitlines():
         match = re.search(re.escape(PROCESS_NAME_PATTERN), line)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -28,8 +28,6 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 ZOOKEEPER_NAME = "zookeeper-k8s"
-TEST_CHARM_PATH = "./tests/integration/app-charm"
-TEST_CHARM_NAME = "application"
 ZOOKEEPER_PORT = 2181
 
 PROCESS_NAME_PATTERN = "org.apache.kyuubi.server.KyuubiServer"
@@ -432,7 +430,7 @@ async def get_address(ops_test: OpsTest, unit_name: str) -> str:
 
 async def deploy_minimal_kyuubi_setup(
     ops_test: OpsTest,
-    kyuubi_charm: str,
+    kyuubi_charm: str | Path,
     charm_versions,
     s3_bucket_and_creds,
     trust: bool = True,

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 import uuid
 from pathlib import Path
 

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -7,20 +7,14 @@ import time
 import uuid
 from pathlib import Path
 
-import psycopg2
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 from thrift.transport.TTransport import TTransportException
 
-from constants import AUTHENTICATION_DATABASE_NAME
-from core.domain import Status
-
 from .helpers import (
-    check_status,
     deploy_minimal_kyuubi_setup,
     find_leader_unit,
-    get_address,
     validate_sql_queries_with_kyuubi,
 )
 
@@ -54,75 +48,11 @@ async def test_deploy_minimal_kyuubi_setup(
             APP_NAME,
             charm_versions.integration_hub.application_name,
             charm_versions.s3.application_name,
+            charm_versions.auth_db.application_name,
         ],
         idle_period=20,
         status="active",
     )
-
-    # Assert that all charms that were deployed as part of minimal setup are in correct states.
-    assert check_status(ops_test.model.applications[APP_NAME], Status.ACTIVE.value)
-    assert (
-        ops_test.model.applications[charm_versions.integration_hub.application_name].status
-        == "active"
-    )
-    assert ops_test.model.applications[charm_versions.s3.application_name].status == "active"
-
-
-@pytest.mark.abort_on_fail
-async def test_sql_queries_no_authentication(ops_test):
-    """Test running SQL queries when authentication has not yet been enabled."""
-    assert await validate_sql_queries_with_kyuubi(ops_test=ops_test)
-
-
-@pytest.mark.abort_on_fail
-async def test_enable_authentication(ops_test, charm_versions):
-    """Test the Kyuuubi charm by integrating it with external metastore."""
-    # Deploy the charm and wait for waiting status
-    logger.info("Deploying postgresql-k8s charm...")
-    await ops_test.model.deploy(**charm_versions.postgres.deploy_dict())
-
-    logger.info("Waiting for postgresql-k8s and kyuubi-k8s apps to be idle and active...")
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, charm_versions.postgres.application_name], timeout=1000, status="active"
-    )
-
-    logger.info("Integrating kyuubi-k8s charm with postgresql-k8s charm...")
-    await ops_test.model.integrate(charm_versions.postgres.application_name, f"{APP_NAME}:auth-db")
-
-    logger.info("Waiting for postgresql-k8s and kyuubi-k8s charms to be idle...")
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, charm_versions.postgres.application_name], timeout=1000
-    )
-
-    # Assert that both kyuubi-k8s and postgresql-k8s charms are in active state
-    assert check_status(ops_test.model.applications[APP_NAME], Status.ACTIVE.value)
-    assert ops_test.model.applications[charm_versions.postgres.application_name].status == "active"
-
-    postgres_leader = await find_leader_unit(
-        ops_test, app_name=charm_versions.postgres.application_name
-    )
-    assert postgres_leader is not None
-    postgres_host = await get_address(ops_test, unit_name=postgres_leader.name)
-
-    action = await postgres_leader.run_action(
-        action_name="get-password",
-    )
-    result = await action.wait()
-    password = result.results.get("password")
-
-    # Connect to PostgreSQL metastore database
-    connection = psycopg2.connect(
-        host=postgres_host,
-        database=AUTHENTICATION_DATABASE_NAME,
-        user="operator",
-        password=password,
-    )
-
-    with connection.cursor() as cursor:
-        cursor.execute(""" SELECT * FROM kyuubi_users; """)
-        assert cursor.rowcount != 0
-
-    connection.close()
 
 
 @pytest.mark.abort_on_fail
@@ -198,24 +128,3 @@ async def test_set_password_action(ops_test: OpsTest):
     assert await validate_sql_queries_with_kyuubi(
         ops_test=ops_test, username=username, password=new_password
     )
-
-
-@pytest.mark.abort_on_fail
-async def test_remove_authentication(ops_test: OpsTest, test_pod, charm_versions):
-    """Test the JDBC connection when authentication is disabled."""
-    logger.info("Removing relation between postgresql-k8s and kyuubi-k8s over auth-db endpoint...")
-    await ops_test.model.applications[APP_NAME].remove_relation(
-        f"{APP_NAME}:auth-db", f"{charm_versions.postgres.application_name}:database"
-    )
-
-    logger.info("Waiting for postgresql-k8s and kyuubi-k8s apps to be idle and active...")
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, charm_versions.postgres.application_name], timeout=1000, status="active"
-    )
-
-    logger.info(
-        "Waiting for extra 30 seconds as cool-down period before proceeding with the test..."
-    )
-    time.sleep(30)
-
-    assert await validate_sql_queries_with_kyuubi(ops_test=ops_test)

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -28,18 +28,17 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-TEST_CHARM_PATH = "./tests/integration/app-charm"
 TEST_CHARM_NAME = "application"
 INVALID_METASTORE_APP_NAME = "invalid-metastore"
 
 
 @pytest.mark.abort_on_fail
 async def test_deploy_minimal_kyuubi_setup(
-    ops_test,
-    kyuubi_charm,
+    ops_test: OpsTest,
+    kyuubi_charm: Path,
     charm_versions,
     s3_bucket_and_creds,
-):
+) -> None:
     """Deploy the minimal setup for Kyuubi and assert all charms are in active and idle state."""
     await deploy_minimal_kyuubi_setup(
         ops_test=ops_test,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -22,14 +22,11 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-TEST_CHARM_PATH = "./tests/integration/app-charm"
-TEST_CHARM_NAME = "application"
-COS_AGENT_APP_NAME = "grafana-agent-k8s"
 
 
 @pytest.mark.skip_if_deployed
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy_kyuubi(ops_test: OpsTest, kyuubi_charm):
+async def test_build_and_deploy_kyuubi(ops_test: OpsTest, kyuubi_charm: Path) -> None:
     """Test building and deploying the charm without relation with any other charm."""
     image_version = METADATA["resources"]["kyuubi-image"]["upstream-source"]
     resources = {"kyuubi-image": image_version}

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -191,7 +191,7 @@ async def test_enable_authentication(ops_test, charm_versions):
 
     logger.info("Waiting for postgresql-k8s and kyuubi-k8s apps to be idle and active...")
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, charm_versions.postgres.application_name], timeout=1000, status="active"
+        apps=[charm_versions.postgres.application_name], timeout=1000, status="active"
     )
 
     logger.info("Integrating kyuubi-k8s charm with postgresql-k8s charm...")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -78,7 +78,7 @@ async def test_deploy_s3_integrator(ops_test: OpsTest, charm_versions, s3_bucket
     """Test deploying the s3-integrator charm and configuring it."""
     # Deploy the charm and wait for waiting status
     logger.info("Deploying s3-integrator charm...")
-    await ops_test.model.deploy(**charm_versions.s3.deploy_dict()),
+    await ops_test.model.deploy(**charm_versions.s3.deploy_dict())
 
     logger.info("Waiting for s3-integrator app to be idle...")
     await ops_test.model.wait_for_idle(
@@ -124,7 +124,7 @@ async def test_deploy_integration_hub(ops_test: OpsTest, charm_versions):
     """Test deploying the integration hub charm and configuring it."""
     # Deploy the charm and wait for waiting status
     logger.info("Deploying integration-hub charm...")
-    await ops_test.model.deploy(**charm_versions.integration_hub.deploy_dict()),
+    await ops_test.model.deploy(**charm_versions.integration_hub.deploy_dict())
 
     logger.info("Waiting for integration_hub app to be idle and active...")
     await ops_test.model.wait_for_idle(
@@ -287,7 +287,7 @@ async def test_integration_with_zookeeper(ops_test: OpsTest, charm_versions):
     """Test the charm by integrating it with Zookeeper."""
     # Deploy the charm and wait for waiting status
     logger.info("Deploying zookeeper-k8s charm...")
-    await ops_test.model.deploy(**charm_versions.zookeeper.deploy_dict()),
+    await ops_test.model.deploy(**charm_versions.zookeeper.deploy_dict())
 
     logger.info("Waiting for zookeeper app to be active and idle...")
     await ops_test.model.wait_for_idle(

--- a/tests/integration/test_dynamic_allocation.py
+++ b/tests/integration/test_dynamic_allocation.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pytest_operator.plugin import OpsTest
 from spark_test.core.kyuubi import KyuubiClient
 from spark_test.utils import get_spark_executors
 
@@ -23,17 +24,15 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-TEST_CHARM_PATH = "./tests/integration/app-charm"
-TEST_CHARM_NAME = "application"
 
 
 @pytest.mark.abort_on_fail
 async def test_deploy_kyuubi_setup(
-    ops_test,
-    kyuubi_charm,
+    ops_test: OpsTest,
+    kyuubi_charm: Path,
     charm_versions,
     s3_bucket_and_creds,
-):
+) -> None:
     """Deploy the minimal setup for Kyuubi and assert all charms are in active and idle state."""
     await deploy_minimal_kyuubi_setup(
         ops_test=ops_test,

--- a/tests/integration/test_external_access.py
+++ b/tests/integration/test_external_access.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 import yaml
 from juju.errors import JujuUnitError
+from pytest_operator.plugin import OpsTest
 
 from core.domain import Status
 
@@ -24,18 +25,16 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-TEST_CHARM_PATH = "./tests/integration/app-charm"
-TEST_CHARM_NAME = "application"
 
 
 @pytest.mark.abort_on_fail
 async def test_default_deploy(
-    ops_test,
-    kyuubi_charm,
+    ops_test: OpsTest,
+    kyuubi_charm: Path,
     charm_versions,
     s3_bucket_and_creds,
     test_pod,
-):
+) -> None:
     """Test the status of default managed K8s service when Kyuubi is deployed."""
     await deploy_minimal_kyuubi_setup(
         ops_test=ops_test,

--- a/tests/integration/test_external_access.py
+++ b/tests/integration/test_external_access.py
@@ -17,6 +17,7 @@ from .helpers import (
     check_status,
     deploy_minimal_kyuubi_setup,
     fetch_jdbc_endpoint,
+    find_leader_unit,
     is_entire_cluster_responding_requests,
     run_sql_test_against_jdbc_endpoint,
 )
@@ -74,10 +75,26 @@ async def test_default_deploy(
 
     # Run SQL tests against JDBC endpoint
     jdbc_endpoint = await fetch_jdbc_endpoint(ops_test)
-    assert await run_sql_test_against_jdbc_endpoint(
-        ops_test, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint
+    kyuubi_leader = await find_leader_unit(ops_test, app_name=APP_NAME)
+    assert kyuubi_leader is not None
+
+    logger.info("Running action 'get-password' on kyuubi-k8s unit...")
+    action = await kyuubi_leader.run_action(
+        action_name="get-password",
     )
-    assert await is_entire_cluster_responding_requests(ops_test=ops_test, test_pod=test_pod)
+    result = await action.wait()
+
+    password = result.results.get("password")
+    logger.info(f"Fetched password: {password}")
+
+    username = "admin"
+
+    assert await run_sql_test_against_jdbc_endpoint(
+        ops_test, test_pod, username, password, jdbc_endpoint=jdbc_endpoint
+    )
+    assert await is_entire_cluster_responding_requests(
+        ops_test=ops_test, test_pod=test_pod, username=username, password=password
+    )
 
 
 @pytest.mark.abort_on_fail
@@ -99,10 +116,27 @@ async def test_nodeport_service(
     assert_service_status(namespace=ops_test.model_name, service_type="NodePort")
 
     jdbc_endpoint = await fetch_jdbc_endpoint(ops_test)
-    assert await run_sql_test_against_jdbc_endpoint(
-        ops_test, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint
+    kyuubi_leader = await find_leader_unit(ops_test, app_name=APP_NAME)
+    assert kyuubi_leader is not None
+
+    logger.info("Running action 'get-password' on kyuubi-k8s unit...")
+    action = await kyuubi_leader.run_action(
+        action_name="get-password",
     )
-    assert await is_entire_cluster_responding_requests(ops_test=ops_test, test_pod=test_pod)
+    result = await action.wait()
+
+    password = result.results.get("password")
+    logger.info(f"Fetched password: {password}")
+
+    username = "admin"
+
+    assert await run_sql_test_against_jdbc_endpoint(
+        ops_test, test_pod, username, password, jdbc_endpoint=jdbc_endpoint
+    )
+
+    assert await is_entire_cluster_responding_requests(
+        ops_test=ops_test, test_pod=test_pod, username=username, password=password
+    )
 
 
 @pytest.mark.abort_on_fail
@@ -124,10 +158,27 @@ async def test_loadbalancer_service(
     assert_service_status(namespace=ops_test.model_name, service_type="LoadBalancer")
 
     jdbc_endpoint = await fetch_jdbc_endpoint(ops_test)
-    assert await run_sql_test_against_jdbc_endpoint(
-        ops_test, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint
+    kyuubi_leader = await find_leader_unit(ops_test, app_name=APP_NAME)
+    assert kyuubi_leader is not None
+
+    logger.info("Running action 'get-password' on kyuubi-k8s unit...")
+    action = await kyuubi_leader.run_action(
+        action_name="get-password",
     )
-    assert await is_entire_cluster_responding_requests(ops_test=ops_test, test_pod=test_pod)
+    result = await action.wait()
+
+    password = result.results.get("password")
+    logger.info(f"Fetched password: {password}")
+
+    username = "admin"
+
+    assert await run_sql_test_against_jdbc_endpoint(
+        ops_test, test_pod, username, password, jdbc_endpoint=jdbc_endpoint
+    )
+
+    assert await is_entire_cluster_responding_requests(
+        ops_test=ops_test, test_pod=test_pod, username=username, password=password
+    )
 
 
 @pytest.mark.abort_on_fail
@@ -149,10 +200,26 @@ async def test_clusterip_service(
     assert_service_status(namespace=ops_test.model_name, service_type="ClusterIP")
 
     jdbc_endpoint = await fetch_jdbc_endpoint(ops_test)
-    assert await run_sql_test_against_jdbc_endpoint(
-        ops_test, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint
+    kyuubi_leader = await find_leader_unit(ops_test, app_name=APP_NAME)
+    assert kyuubi_leader is not None
+
+    logger.info("Running action 'get-password' on kyuubi-k8s unit...")
+    action = await kyuubi_leader.run_action(
+        action_name="get-password",
     )
-    assert await is_entire_cluster_responding_requests(ops_test=ops_test, test_pod=test_pod)
+    result = await action.wait()
+
+    password = result.results.get("password")
+    logger.info(f"Fetched password: {password}")
+
+    username = "admin"
+
+    assert await run_sql_test_against_jdbc_endpoint(
+        ops_test, test_pod, username, password, jdbc_endpoint=jdbc_endpoint
+    )
+    assert await is_entire_cluster_responding_requests(
+        ops_test=ops_test, test_pod=test_pod, username=username, password=password
+    )
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_ha.py
+++ b/tests/integration/test_ha.py
@@ -32,8 +32,6 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-TEST_CHARM_PATH = "./tests/integration/app-charm"
-TEST_CHARM_NAME = "application"
 
 
 def check_status(entity: Application | Unit, status: StatusBase):
@@ -50,11 +48,11 @@ def check_status(entity: Application | Unit, status: StatusBase):
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy_cluster_with_no_zookeeper(
-    ops_test: OpsTest, kyuubi_charm, charm_versions, s3_bucket_and_creds
-):
+    ops_test: OpsTest, kyuubi_charm: Path, charm_versions, s3_bucket_and_creds
+) -> None:
     await deploy_minimal_kyuubi_setup(
         ops_test=ops_test,
-        kyuubi_charm=kyuubi_charm,
+        kyuubi_charm=str(kyuubi_charm),
         charm_versions=charm_versions,
         s3_bucket_and_creds=s3_bucket_and_creds,
         trust=True,

--- a/tests/integration/test_ha.py
+++ b/tests/integration/test_ha.py
@@ -79,7 +79,21 @@ async def test_build_and_deploy_cluster_with_no_zookeeper(
 
 @pytest.mark.abort_on_fail
 async def test_standalone_kyuubi_works_without_zookeeper(ops_test: OpsTest, test_pod):
-    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod)
+    kyuubi_leader = await find_leader_unit(ops_test, app_name=APP_NAME)
+    assert kyuubi_leader is not None
+
+    logger.info("Running action 'get-password' on kyuubi-k8s unit...")
+    action = await kyuubi_leader.run_action(
+        action_name="get-password",
+    )
+    result = await action.wait()
+
+    password = result.results.get("password")
+    logger.info(f"Fetched password: {password}")
+
+    username = "admin"
+
+    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod, username, password)
 
 
 @pytest.mark.abort_on_fail
@@ -146,7 +160,21 @@ async def test_zookeeper_relation_with_three_units_of_kyuubi(
     assert set(active_servers) == set(expected_servers)
 
     # Run SQL test against the cluster
-    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod)
+    kyuubi_leader = await find_leader_unit(ops_test, app_name=APP_NAME)
+    assert kyuubi_leader is not None
+
+    logger.info("Running action 'get-password' on kyuubi-k8s unit...")
+    action = await kyuubi_leader.run_action(
+        action_name="get-password",
+    )
+    result = await action.wait()
+
+    password = result.results.get("password")
+    logger.info(f"Fetched password: {password}")
+
+    username = "admin"
+
+    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod, username, password)
 
     # Assert the entire cluster is usable
     assert await is_entire_cluster_responding_requests(ops_test, test_pod)
@@ -174,7 +202,21 @@ async def test_pod_reschedule(ops_test: OpsTest, test_pod, charm_versions):
     assert len(active_servers) == 3
 
     # Run SQL test against the cluster
-    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod)
+    kyuubi_leader = await find_leader_unit(ops_test, app_name=APP_NAME)
+    assert kyuubi_leader is not None
+
+    logger.info("Running action 'get-password' on kyuubi-k8s unit...")
+    action = await kyuubi_leader.run_action(
+        action_name="get-password",
+    )
+    result = await action.wait()
+
+    password = result.results.get("password")
+    logger.info(f"Fetched password: {password}")
+
+    username = "admin"
+
+    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod, username, password)
 
     # Assert the entire cluster is usable
     assert await is_entire_cluster_responding_requests(ops_test, test_pod)
@@ -215,7 +257,21 @@ async def test_kill_kyuubi_process(ops_test: OpsTest, test_pod, charm_versions):
     assert len(active_servers) == 3
 
     # Run SQL test against the cluster
-    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod)
+    kyuubi_leader = await find_leader_unit(ops_test, app_name=APP_NAME)
+    assert kyuubi_leader is not None
+
+    logger.info("Running action 'get-password' on kyuubi-k8s unit...")
+    action = await kyuubi_leader.run_action(
+        action_name="get-password",
+    )
+    result = await action.wait()
+
+    password = result.results.get("password")
+    logger.info(f"Fetched password: {password}")
+
+    username = "admin"
+
+    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod, username, password)
 
     # Assert the entire cluster is usable
     assert await is_entire_cluster_responding_requests(ops_test, test_pod)
@@ -246,7 +302,20 @@ async def test_scale_down_kyuubi_from_three_to_two_with_zookeeper(
     assert len(active_servers) == 2
 
     # Run SQL test against the cluster
-    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod)
+    kyuubi_leader = await find_leader_unit(ops_test, app_name=APP_NAME)
+    assert kyuubi_leader is not None
+
+    logger.info("Running action 'get-password' on kyuubi-k8s unit...")
+    action = await kyuubi_leader.run_action(
+        action_name="get-password",
+    )
+    result = await action.wait()
+
+    password = result.results.get("password")
+    logger.info(f"Fetched password: {password}")
+
+    username = "admin"
+    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod, username, password)
 
     # Assert the entire cluster is usable
     assert await is_entire_cluster_responding_requests(ops_test, test_pod)
@@ -276,7 +345,21 @@ async def test_scale_down_to_standalone_kyuubi_with_zookeeper(
     assert len(active_servers) == 1
 
     # Run SQL test against the cluster
-    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod)
+    kyuubi_leader = await find_leader_unit(ops_test, app_name=APP_NAME)
+    assert kyuubi_leader is not None
+
+    logger.info("Running action 'get-password' on kyuubi-k8s unit...")
+    action = await kyuubi_leader.run_action(
+        action_name="get-password",
+    )
+    result = await action.wait()
+
+    password = result.results.get("password")
+    logger.info(f"Fetched password: {password}")
+
+    username = "admin"
+
+    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod, username, password)
 
     # Assert the entire cluster is usable
     assert await is_entire_cluster_responding_requests(ops_test, test_pod)
@@ -302,4 +385,18 @@ async def test_remove_zookeeper_relation_on_single_unit(
     )
 
     # Run SQL test against the standalone Kyuubi
-    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod)
+    kyuubi_leader = await find_leader_unit(ops_test, app_name=APP_NAME)
+    assert kyuubi_leader is not None
+
+    logger.info("Running action 'get-password' on kyuubi-k8s unit...")
+    action = await kyuubi_leader.run_action(
+        action_name="get-password",
+    )
+    result = await action.wait()
+
+    password = result.results.get("password")
+    logger.info(f"Fetched password: {password}")
+
+    username = "admin"
+
+    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod, username, password)

--- a/tests/integration/test_ha.py
+++ b/tests/integration/test_ha.py
@@ -188,9 +188,9 @@ async def test_kill_kyuubi_process(ops_test: OpsTest, test_pod, charm_versions):
 
     # Get the current PID of Kyuubi process
     kyuubi_pid_old = await get_kyuubi_pid(ops_test, leader_unit)
-    assert (
-        kyuubi_pid_old is not None
-    ), f"No Kyuubi process found running in the unit {leader_unit.name}"
+    assert kyuubi_pid_old is not None, (
+        f"No Kyuubi process found running in the unit {leader_unit.name}"
+    )
 
     # Kill Kyuubi process inside the leader unit
     await kill_kyuubi_process(ops_test, leader_unit, kyuubi_pid_old)

--- a/tests/integration/test_ha.py
+++ b/tests/integration/test_ha.py
@@ -177,7 +177,7 @@ async def test_zookeeper_relation_with_three_units_of_kyuubi(
     assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod, username, password)
 
     # Assert the entire cluster is usable
-    assert await is_entire_cluster_responding_requests(ops_test, test_pod)
+    assert await is_entire_cluster_responding_requests(ops_test, test_pod, username, password)
 
 
 async def test_pod_reschedule(ops_test: OpsTest, test_pod, charm_versions):
@@ -219,7 +219,7 @@ async def test_pod_reschedule(ops_test: OpsTest, test_pod, charm_versions):
     assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod, username, password)
 
     # Assert the entire cluster is usable
-    assert await is_entire_cluster_responding_requests(ops_test, test_pod)
+    assert await is_entire_cluster_responding_requests(ops_test, test_pod, username, password)
 
 
 async def test_kill_kyuubi_process(ops_test: OpsTest, test_pod, charm_versions):
@@ -274,7 +274,7 @@ async def test_kill_kyuubi_process(ops_test: OpsTest, test_pod, charm_versions):
     assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod, username, password)
 
     # Assert the entire cluster is usable
-    assert await is_entire_cluster_responding_requests(ops_test, test_pod)
+    assert await is_entire_cluster_responding_requests(ops_test, test_pod, username, password)
 
 
 @pytest.mark.abort_on_fail
@@ -318,7 +318,7 @@ async def test_scale_down_kyuubi_from_three_to_two_with_zookeeper(
     assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod, username, password)
 
     # Assert the entire cluster is usable
-    assert await is_entire_cluster_responding_requests(ops_test, test_pod)
+    assert await is_entire_cluster_responding_requests(ops_test, test_pod, username, password)
 
 
 @pytest.mark.abort_on_fail
@@ -362,7 +362,7 @@ async def test_scale_down_to_standalone_kyuubi_with_zookeeper(
     assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod, username, password)
 
     # Assert the entire cluster is usable
-    assert await is_entire_cluster_responding_requests(ops_test, test_pod)
+    assert await is_entire_cluster_responding_requests(ops_test, test_pod, username, password)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_iceberg.py
+++ b/tests/integration/test_iceberg.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pytest_operator.plugin import OpsTest
 from spark_test.core.kyuubi import KyuubiClient
 
 from core.domain import Status
@@ -21,17 +22,15 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-TEST_CHARM_PATH = "./tests/integration/app-charm"
-TEST_CHARM_NAME = "application"
 
 
 @pytest.mark.abort_on_fail
 async def test_deploy_kyuubi_setup(
-    ops_test,
-    kyuubi_charm,
+    ops_test: OpsTest,
+    kyuubi_charm: Path,
     charm_versions,
     s3_bucket_and_creds,
-):
+) -> None:
     """Deploy the minimal setup for Kyuubi and assert all charms are in active and idle state."""
     await deploy_minimal_kyuubi_setup(
         ops_test=ops_test,

--- a/tests/integration/test_metastore.py
+++ b/tests/integration/test_metastore.py
@@ -25,8 +25,6 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-TEST_CHARM_PATH = "./tests/integration/app-charm"
-TEST_CHARM_NAME = "application"
 INVALID_METASTORE_APP_NAME = "invalid-metastore"
 TEST_EXTERNAL_DB_NAME = "dbext"
 TEST_EXTERNAL_TABLE_NAME = "text"
@@ -35,10 +33,10 @@ TEST_EXTERNAL_TABLE_NAME = "text"
 @pytest.mark.abort_on_fail
 async def test_deploy_minimal_kyuubi_setup(
     ops_test,
-    kyuubi_charm,
+    kyuubi_charm: Path,
     charm_versions,
     s3_bucket_and_creds,
-):
+) -> None:
     """Deploy the minimal setup for Kyuubi and assert all charms are in active and idle state."""
     await deploy_minimal_kyuubi_setup(
         ops_test=ops_test,
@@ -176,7 +174,7 @@ async def test_remove_external_metastore(ops_test, charm_versions):
 
 
 @pytest.mark.abort_on_fail
-async def test_run_sql_queries_again_with_local_metastore(ops_test, charm_versions):
+async def test_run_sql_queries_again_with_local_metastore(ops_test):
     """Test running SQL queries again with local metastore."""
     logger.info(
         "Waiting for extra 30 seconds as cool-down period before proceeding with the test..."

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -162,6 +162,7 @@ async def test_kyuubi_cos_monitoring_setup(ops_test: OpsTest):
         status="active",
         timeout=1000,
         idle_period=30,
+        raise_on_error=False,
     )
 
 

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -156,7 +156,6 @@ async def test_kyuubi_cos_data_published(ops_test: OpsTest):
     # We should leave time for Prometheus data to be published
     for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(60), reraise=True):
         with attempt:
-
             # Data got published to Prometheus
             logger.info("Checking if Prometheus data is being published...")
             cos_address = await get_cos_address(ops_test)

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -29,16 +29,14 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-TEST_CHARM_PATH = "./tests/integration/app-charm"
-TEST_CHARM_NAME = "application"
 COS_AGENT_APP_NAME = "grafana-agent-k8s"
 
 
 @pytest.mark.skip_if_deployed
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(
-    ops_test: OpsTest, kyuubi_charm, charm_versions, s3_bucket_and_creds
-):
+    ops_test: OpsTest, kyuubi_charm: Path, charm_versions, s3_bucket_and_creds
+) -> None:
     """Deploy minimal Kyuubi deployments."""
     """Test the status of default managed K8s service when Kyuubi is deployed."""
     await deploy_minimal_kyuubi_setup(

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -90,9 +90,9 @@ async def test_kyuubi_client_relation_joined(
 
     # Fetch host address of postgresql-k8s
     status = await ops_test.model.get_status()
-    postgresql_host_address = status["applications"][charm_versions.postgres.application_name][
+    postgresql_host_address = status["applications"][charm_versions.auth_db.application_name][
         "units"
-    ][f"{charm_versions.postgres.application_name}/0"]["address"]
+    ][f"{charm_versions.auth_db.application_name}/0"]["address"]
 
     # Connect to PostgreSQL authentication database
     connection = psycopg2.connect(

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -30,18 +30,16 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-TEST_CHARM_PATH = "./tests/integration/app-charm"
 TEST_CHARM_NAME = "application"
-COS_AGENT_APP_NAME = "grafana-agent-k8s"
 
 
 @pytest.mark.abort_on_fail
 async def test_deploy_minimal_kyuubi_setup(
-    ops_test,
-    kyuubi_charm,
+    ops_test: OpsTest,
+    kyuubi_charm: Path,
     charm_versions,
     s3_bucket_and_creds,
-):
+) -> None:
     """Deploy the minimal setup for Kyuubi and assert all charms are in active and idle state."""
     await deploy_minimal_kyuubi_setup(
         ops_test=ops_test,
@@ -96,15 +94,14 @@ async def test_enable_authentication(ops_test: OpsTest, charm_versions):
 
 
 @pytest.mark.abort_on_fail
-async def test_kyuubi_client_relation_joined(ops_test: OpsTest, charm_versions):
+async def test_kyuubi_client_relation_joined(
+    ops_test: OpsTest, charm_versions, test_charm: Path
+) -> None:
     """Test behavior of Kyuubi charm when a client application is related to it."""
-    logger.info("Building test charm (app-charm)...")
-    app_charm = await ops_test.build_charm(TEST_CHARM_PATH)
-
     # Deploy the test charm and wait for waiting status
     logger.info("Deploying test charm...")
     await ops_test.model.deploy(
-        app_charm,
+        test_charm,
         application_name=TEST_CHARM_NAME,
         num_units=1,
         series="jammy",

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -24,6 +24,7 @@ from core.domain import Status
 from .helpers import (
     assert_service_status,
     deploy_minimal_kyuubi_setup,
+    find_leader_unit,
     get_address,
     run_command_in_pod,
     run_sql_test_against_jdbc_endpoint,
@@ -106,8 +107,21 @@ async def test_jdbc_endpoint_with_default_metastore(ops_test: OpsTest, test_pod)
     logger.info(
         "Testing JDBC endpoint by connecting with beeline and executing a few SQL queries..."
     )
+    kyuubi_leader = await find_leader_unit(ops_test, app_name=APP_NAME)
+    assert kyuubi_leader is not None
 
-    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod)
+    logger.info("Running action 'get-password' on kyuubi-k8s unit...")
+    action = await kyuubi_leader.run_action(
+        action_name="get-password",
+    )
+    result = await action.wait()
+
+    password = result.results.get("password")
+    logger.info(f"Fetched password: {password}")
+
+    username = "admin"
+
+    assert await run_sql_test_against_jdbc_endpoint(ops_test, test_pod, username, password)
 
 
 @pytest.mark.abort_on_fail
@@ -228,9 +242,22 @@ async def test_enable_ssl(ops_test: OpsTest, charm_versions, test_pod):
     logger.info(
         "Testing JDBC endpoint by connecting with beeline and executing a few SQL queries..."
     )
+    kyuubi_leader = await find_leader_unit(ops_test, app_name=APP_NAME)
+    assert kyuubi_leader is not None
+
+    logger.info("Running action 'get-password' on kyuubi-k8s unit...")
+    action = await kyuubi_leader.run_action(
+        action_name="get-password",
+    )
+    result = await action.wait()
+
+    password = result.results.get("password")
+    logger.info(f"Fetched password: {password}")
+
+    username = "admin"
 
     assert await run_sql_test_against_jdbc_endpoint(
-        ops_test, test_pod, jdbc_endpoint=jdbc_endpoint_ssl
+        ops_test, test_pod, username, password, jdbc_endpoint=jdbc_endpoint_ssl
     )
 
 
@@ -358,8 +385,22 @@ async def test_loadbalancer_service(
     logger.info(
         "Testing JDBC endpoint by connecting with beeline and executing a few SQL queries..."
     )
+    kyuubi_leader = await find_leader_unit(ops_test, app_name=APP_NAME)
+    assert kyuubi_leader is not None
+
+    logger.info("Running action 'get-password' on kyuubi-k8s unit...")
+    action = await kyuubi_leader.run_action(
+        action_name="get-password",
+    )
+    result = await action.wait()
+
+    password = result.results.get("password")
+    logger.info(f"Fetched password: {password}")
+
+    username = "admin"
+
     assert await run_sql_test_against_jdbc_endpoint(
-        ops_test, test_pod, jdbc_endpoint=jdbc_endpoint_ssl
+        ops_test, test_pod, username, password, jdbc_endpoint=jdbc_endpoint_ssl
     )
 
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -55,8 +55,8 @@ def check_status(entity: Application | Unit, status: StatusBase):
 @pytest.mark.skip_if_deployed
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(
-    ops_test: OpsTest, kyuubi_charm, charm_versions, s3_bucket_and_creds
-):
+    ops_test: OpsTest, kyuubi_charm: Path, charm_versions, s3_bucket_and_creds
+) -> None:
     """Deploy minimal Kyuubi deployments."""
     """Test the status of default managed K8s service when Kyuubi is deployed."""
     await deploy_minimal_kyuubi_setup(

--- a/tests/integration/test_trust.py
+++ b/tests/integration/test_trust.py
@@ -20,8 +20,6 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-TEST_CHARM_PATH = "./tests/integration/app-charm"
-TEST_CHARM_NAME = "application"
 
 
 def check_status(entity: Application | Unit, status: StatusBase):
@@ -38,8 +36,8 @@ def check_status(entity: Application | Unit, status: StatusBase):
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(
-    ops_test: OpsTest, kyuubi_charm, charm_versions, s3_bucket_and_creds
-):
+    ops_test: OpsTest, kyuubi_charm: Path, charm_versions, s3_bucket_and_creds
+) -> None:
     await deploy_minimal_kyuubi_setup(
         ops_test=ops_test,
         kyuubi_charm=kyuubi_charm,

--- a/tests/integration/test_trust.py
+++ b/tests/integration/test_trust.py
@@ -72,7 +72,6 @@ async def test_build_and_deploy(
 
 @pytest.mark.abort_on_fail
 async def test_provide_clusterwide_trust_permissions(ops_test):
-
     # Add cluster-wisde trust permission on the application
     await ops_test.juju("trust", APP_NAME, "--scope=cluster")
 

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -21,9 +21,6 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-TEST_CHARM_PATH = "./tests/integration/app-charm"
-TEST_CHARM_NAME = "application"
-COS_AGENT_APP_NAME = "grafana-agent-k8s"
 
 
 def check_status(entity: Application | Unit, status: StatusBase):
@@ -93,7 +90,9 @@ async def test_build_and_deploy(ops_test: OpsTest, charm_versions, s3_bucket_and
 
 
 @pytest.mark.abort_on_fail
-async def test_kyuubi_upgrades(ops_test: OpsTest, kyuubi_charm, test_pod, charm_versions):
+async def test_kyuubi_upgrades(
+    ops_test: OpsTest, kyuubi_charm: Path, test_pod, charm_versions
+) -> None:
     """Test the correct upgrade of a Kyuubi cluster."""
     # Retrieve the image to use from metadata.yaml
     image_version = METADATA["resources"]["kyuubi-image"]["upstream-source"]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,6 +10,7 @@ from ops.testing import Container, Context, Model, Mount, Relation
 from charm import KyuubiCharm
 from constants import (
     KYUUBI_CONTAINER_NAME,
+    POSTGRESQL_AUTH_DB_REL,
     SPARK_SERVICE_ACCOUNT_REL,
     ZOOKEEPER_REL,
 )
@@ -72,6 +73,24 @@ def spark_service_account_relation():
         remote_app_name="integration-hub",
         local_app_data={"service-account": "spark:kyuubi", "spark-properties": "{'foo':'bar'}"},
         remote_app_data={"service-account": "spark:kyuubi", "spark-properties": '{"foo":"bar"}'},
+    )
+
+
+@pytest.fixture
+def auth_db_relation() -> Relation:
+    return Relation(
+        endpoint=POSTGRESQL_AUTH_DB_REL,
+        interface="postgresql_client",
+        remote_app_name="kyuubi-users",
+        local_app_data={
+            "database": "kyuubi-users",
+        },
+        remote_app_data={
+            "database": "myappB",
+            "endpoints": "postgresql-k8s-primary:5432",
+            "username": "kyuubi",
+            "password": "pwd",
+        },
     )
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -278,7 +278,10 @@ def test_zookeeper_relation_broken(
         kyuubi_context.on.relation_changed(zookeeper_relation), state
     )
     state_after_relation_broken = kyuubi_context.run(
-        kyuubi_context.on.relation_broken(zookeeper_relation), state_after_relation_changed
+        kyuubi_context.on.relation_broken(
+            state_after_relation_changed.get_relation(zookeeper_relation.id)
+        ),
+        state_after_relation_changed,
     )
     assert state_after_relation_broken.unit_status == Status.ACTIVE.value
 
@@ -322,7 +325,9 @@ def test_spark_service_account_broken(
         kyuubi_context.on.relation_changed(spark_service_account_relation), initial_state
     )
     state_after_relation_broken = kyuubi_context.run(
-        kyuubi_context.on.relation_broken(spark_service_account_relation),
+        kyuubi_context.on.relation_broken(
+            state_after_relation_changed.get_relation(spark_service_account_relation.id)
+        ),
         state_after_relation_changed,
     )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -109,9 +109,10 @@ def test_service_unavailable(
     kyuubi_context: Context,
     kyuubi_container: Container,
     spark_service_account_relation: Relation,
+    auth_db_relation: Relation,
 ) -> None:
     state = State(
-        relations=[spark_service_account_relation],
+        relations=[spark_service_account_relation, auth_db_relation],
         containers=[kyuubi_container],
     )
     out = kyuubi_context.run(kyuubi_context.on.config_changed(), state)
@@ -142,9 +143,10 @@ def test_valid_on_service_account(
     kyuubi_context: Context,
     kyuubi_container: Container,
     spark_service_account_relation: Relation,
+    auth_db_relation: Relation,
 ) -> None:
     state = State(
-        relations=[spark_service_account_relation],
+        relations=[spark_service_account_relation, auth_db_relation],
         containers=[kyuubi_container],
     )
     out = kyuubi_context.run(
@@ -220,10 +222,11 @@ def test_zookeeper_relation_joined(
     kyuubi_context: Context,
     kyuubi_container: Container,
     spark_service_account_relation: Relation,
+    auth_db_relation: Relation,
     zookeeper_relation: Relation,
 ):
     state = State(
-        relations=[spark_service_account_relation, zookeeper_relation],
+        relations=[spark_service_account_relation, auth_db_relation, zookeeper_relation],
         containers=[kyuubi_container],
     )
     out = kyuubi_context.run(kyuubi_context.on.relation_changed(zookeeper_relation), state)
@@ -268,10 +271,11 @@ def test_zookeeper_relation_broken(
     kyuubi_context: Context,
     kyuubi_container: Container,
     spark_service_account_relation: Relation,
+    auth_db_relation: Relation,
     zookeeper_relation: Relation,
 ) -> None:
     state = State(
-        relations=[spark_service_account_relation, zookeeper_relation],
+        relations=[spark_service_account_relation, auth_db_relation, zookeeper_relation],
         containers=[kyuubi_container],
     )
     state_after_relation_changed = kyuubi_context.run(
@@ -402,9 +406,10 @@ def test_missing_zookeeper_for_multiple_units_of_kyuubi(
     kyuubi_context: Context,
     kyuubi_container: Container,
     spark_service_account_relation: Relation,
+    auth_db_relation: Relation,
 ) -> None:
     state = State(
-        relations=[spark_service_account_relation],
+        relations=[spark_service_account_relation, auth_db_relation],
         containers=[kyuubi_container],
     )
     out = kyuubi_context.run(kyuubi_context.on.pebble_ready(kyuubi_container), state)
@@ -439,9 +444,10 @@ def test_spark_property_priorities(
     kyuubi_context: Context,
     kyuubi_container: Container,
     spark_service_account_relation: Relation,
+    auth_db_relation: Relation,
 ):
     state = State(
-        relations=[spark_service_account_relation],
+        relations=[spark_service_account_relation, auth_db_relation],
         containers=[kyuubi_container],
     )
     out = kyuubi_context.run(

--- a/tox.ini
+++ b/tox.ini
@@ -44,8 +44,8 @@ deps =
 description = Apply coding style standards to code
 commands =
     poetry install --only format
+    poetry run ruff format {[vars]all_path}
     poetry run ruff check --fix {[vars]all_path}
-    poetry run black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
@@ -64,7 +64,7 @@ commands =
         --skip {tox_root}/icon.svg 
 
     poetry run ruff check {[vars]all_path}
-    poetry run black --check --diff {[vars]all_path}
+    poetry run ruff format --check --diff {[vars]all_path}
 
 
 [testenv:unit]

--- a/tox.ini
+++ b/tox.ini
@@ -63,8 +63,10 @@ commands =
         --skip {tox_root}/tests/integration/app-charm/lib \
         --skip {tox_root}/icon.svg 
 
-    poetry run ruff check {[vars]all_path}
+    poetry run ruff check --fix {[vars]all_path}
     poetry run ruff format --check --diff {[vars]all_path}
+    poetry install --with lint
+    poetry run mypy src
 
 
 [testenv:unit]


### PR DESCRIPTION
## Changes

- Make `auth-db` relation mandatory. The charm won't start without it, with an appropriate blocked status
- This PR includes a bunch of housekeeping items from #73.  I had already fixed some stuff there, and was more confident in creating a branch from this point. It should be fairly straightforward to review though.

The integration tests are super verbose now, with the username and password needed everywhere. I kindly ask for your understanding here: since we have a full rewrite to jubilant coming up, I did not bother with making the changes as maintainable as I would usually do.