### PR TITLE
[DPE-7126] Improve TIOBE scan by installing dependencies on runner

### DIFF
--- a/.github/workflows/tiobe_scan.yaml
+++ b/.github/workflows/tiobe_scan.yaml
@@ -35,6 +35,14 @@ jobs:
           pipx install tox
           pipx install poetry
 
+      - name: Create and activate virtual environment
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
+          pip install flake8 poetry pylint pytest tox
+          poetry install --all-groups
+          echo PATH="$PATH" >> "$GITHUB_ENV"
+
       - name: Run tox tests to create coverage.xml
         run: tox run -e unit
 


### PR DESCRIPTION
This PR address the warning of the TIOBE scan that shows that some of the dependencies like `ops`, `cosl` and others cannot be  resolved.