### PR TITLE
[DPE-7460] Remove get-jdbc-endpoint action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,10 +1,6 @@
 # Copyright 2024 Canonical Limited
 # See LICENSE file for licensing details.
 
-get-jdbc-endpoint:
-  description: |
-    Returns the JDBC endpoint to connect to Kyuubi server.
-
 get-password:
   description: |
     Returns the password for the admin user.

--- a/src/core/context.py
+++ b/src/core/context.py
@@ -17,6 +17,7 @@ from common.relation.spark_sa import SparkServiceAccountRequirerData
 from constants import (
     AUTHENTICATION_DATABASE_NAME,
     HA_ZNODE_NAME,
+    KYUUBI_CLIENT_RELATION_NAME,
     METASTORE_DATABASE_NAME,
     PEER_REL,
     POSTGRESQL_AUTH_DB_REL,
@@ -188,3 +189,8 @@ class Context(WithLogging):
             data_interface=self.peer_app_interface,
             component=self.model.app,
         )
+
+    @property
+    def client_relations(self) -> set[Relation]:
+        """The relations of all client applications."""
+        return set(self.model.relations[KYUUBI_CLIENT_RELATION_NAME])

--- a/src/events/kyuubi.py
+++ b/src/events/kyuubi.py
@@ -72,9 +72,10 @@ class KyuubiEvents(BaseEventHandler, WithLogging):
         """Handle the on_config_changed event."""
         if self.charm.unit.is_leader():
             # Create / update the managed service to reflect the service type in config
-            self.service_manager.reconcile_services(
+            if self.service_manager.reconcile_services(
                 self.charm.config.expose_external, self.charm.config.loadbalancer_extra_annotations
-            )
+            ):
+                self.charm.provider_events.update_clients_endpoints()
 
         self.kyuubi.update()
 
@@ -183,3 +184,4 @@ class KyuubiEvents(BaseEventHandler, WithLogging):
         self.logger.info("Kyuubi peer relation changed...")
         # check if certificate need to be reloaded
         self.check_if_certificate_needs_reload()
+        self.charm.provider_events.update_clients_endpoints()

--- a/src/managers/service.py
+++ b/src/managers/service.py
@@ -216,8 +216,11 @@ class ServiceManager(WithLogging):
             return False
         return True
 
-    def reconcile_services(self, expose_external: str, lb_extra_annotation: str) -> None:
-        """Update the services according to the desired service type."""
+    def reconcile_services(self, expose_external: str, lb_extra_annotation: str) -> bool:
+        """Update the services according to the desired service type.
+
+        Return True in case of service reconciliation.
+        """
         desired_service_type = {
             "false": _ServiceType.CLUSTER_IP,
             "nodeport": _ServiceType.NODE_PORT,
@@ -243,7 +246,7 @@ class ServiceManager(WithLogging):
                 self.logger.info(
                     f"Kyuubi is already exposed on a service of type {desired_service_type}."
                 )
-                return
+                return False
 
             # self.delete_service()
 
@@ -254,6 +257,7 @@ class ServiceManager(WithLogging):
             owner_references=getattr(pod0.metadata, "ownerReferences", []),
             annotations=annotations,
         )
+        return True
 
     def get_node_ip(self, pod_name: str) -> str:
         """Gets the IP Address of the Node of a given Pod via the K8s API."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -88,17 +88,24 @@ def charm_versions() -> IntegrationTestsCharms:
         ),
         zookeeper=TestCharm(
             name="zookeeper-k8s",
-            channel="3/edge",
+            channel="3/stable",
             revision=70,
             base="ubuntu@22.04",
             alias="zookeeper",
         ),
         tls=TestCharm(
             name="self-signed-certificates",
-            channel="edge",
+            channel="latest/stable",
             revision=163,  # FIXME (certs): Unpin the revision once the charm is fixed
             base="ubuntu@22.04",
             alias="self-signed-certificates",
+        ),
+        data_integrator=TestCharm(
+            name="data-integrator",
+            channel="latest/stable",
+            revision=161,
+            base="ubuntu@22.04",
+            alias="data-integrator",
         ),
     )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -89,7 +89,7 @@ def charm_versions() -> IntegrationTestsCharms:
         zookeeper=TestCharm(
             name="zookeeper-k8s",
             channel="3/stable",
-            revision=70,
+            revision=78,
             base="ubuntu@22.04",
             alias="zookeeper",
         ),

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -13,7 +13,7 @@ from thrift.transport.TTransport import TTransportException
 
 from .helpers import (
     deploy_minimal_kyuubi_setup,
-    fetch_password,
+    fetch_connection_info,
     get_leader_unit,
     validate_sql_queries_with_kyuubi,
 )
@@ -58,11 +58,12 @@ def test_kyuubi_with_invalid_credentials(juju: jubilant.Juju) -> None:
         validate_sql_queries_with_kyuubi(juju=juju, username=username, password=password)
 
 
-def test_kyuubi_valid_credentials(juju: jubilant.Juju) -> None:
+def test_kyuubi_valid_credentials(
+    juju: jubilant.Juju, charm_versions: IntegrationTestsCharms
+) -> None:
     """Test the JDBC connection when invalid credentials are provided."""
     logger.info("Running action 'get-password' on kyuubi unit")
-    username = "admin"
-    password = fetch_password(juju)
+    _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
     assert validate_sql_queries_with_kyuubi(juju=juju, username=username, password=password)
 
 

--- a/tests/integration/test_external_access.py
+++ b/tests/integration/test_external_access.py
@@ -13,8 +13,7 @@ import yaml
 from .helpers import (
     assert_service_status,
     deploy_minimal_kyuubi_setup,
-    fetch_jdbc_endpoint,
-    fetch_password,
+    fetch_connection_info,
     is_entire_cluster_responding_requests,
     run_sql_test_against_jdbc_endpoint,
 )
@@ -50,22 +49,21 @@ def test_default_deploy(
     # Ensure that Kyuubi is exposed with ClusterIP service
     assert_service_status(namespace=cast(str, juju.model), service_type="ClusterIP")
 
-    username = "admin"
-    password = fetch_password(juju)
+    jdbc_endpoint, username, password = fetch_connection_info(
+        juju, charm_versions.data_integrator.app
+    )
 
     # Run SQL tests against JDBC endpoint
-    jdbc_endpoint = fetch_jdbc_endpoint(juju)
     assert run_sql_test_against_jdbc_endpoint(
         juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
     assert is_entire_cluster_responding_requests(
-        juju, test_pod=test_pod, username=username, password=password
+        juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
 
 
 def test_nodeport_service(
-    juju: jubilant.Juju,
-    test_pod: str,
+    juju: jubilant.Juju, test_pod: str, charm_versions: IntegrationTestsCharms
 ) -> None:
     """Test the status of managed K8s service when `expose-external` is set to 'nodeport'."""
     logger.info("Changing expose-external to 'nodeport' for kyuubi-k8s charm...")
@@ -79,22 +77,21 @@ def test_nodeport_service(
 
     assert_service_status(namespace=cast(str, juju.model), service_type="NodePort")
 
-    username = "admin"
-    password = fetch_password(juju)
+    jdbc_endpoint, username, password = fetch_connection_info(
+        juju, charm_versions.data_integrator.app
+    )
 
     # Run SQL tests against JDBC endpoint
-    jdbc_endpoint = fetch_jdbc_endpoint(juju)
     assert run_sql_test_against_jdbc_endpoint(
         juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
     assert is_entire_cluster_responding_requests(
-        juju, test_pod=test_pod, username=username, password=password
+        juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
 
 
 def test_loadbalancer_service(
-    juju: jubilant.Juju,
-    test_pod: str,
+    juju: jubilant.Juju, test_pod: str, charm_versions: IntegrationTestsCharms
 ) -> None:
     """Test the status of managed K8s service when `expose-external` is set to 'loadbalancer'."""
     logger.info("Changing expose-external to 'nodeport' for kyuubi-k8s charm...")
@@ -116,22 +113,21 @@ def test_loadbalancer_service(
     annotations = getattr(service.metadata, "annotations", {})
     assert annotations.get("foo", "") == "bar"
 
-    username = "admin"
-    password = fetch_password(juju)
+    jdbc_endpoint, username, password = fetch_connection_info(
+        juju, charm_versions.data_integrator.app
+    )
 
     # Run SQL tests against JDBC endpoint
-    jdbc_endpoint = fetch_jdbc_endpoint(juju)
     assert run_sql_test_against_jdbc_endpoint(
         juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
     assert is_entire_cluster_responding_requests(
-        juju, test_pod=test_pod, username=username, password=password
+        juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
 
 
 def test_clusterip_service(
-    juju: jubilant.Juju,
-    test_pod: str,
+    juju: jubilant.Juju, test_pod: str, charm_versions: IntegrationTestsCharms
 ) -> None:
     """Test the status of managed K8s service when `expose-external` is set to 'false'."""
     logger.info("Changing expose-external to 'false' for kyuubi-k8s charm...")
@@ -144,16 +140,16 @@ def test_clusterip_service(
     )
     assert_service_status(namespace=cast(str, juju.model), service_type="ClusterIP")
 
-    username = "admin"
-    password = fetch_password(juju)
+    jdbc_endpoint, username, password = fetch_connection_info(
+        juju, charm_versions.data_integrator.app
+    )
 
     # Run SQL tests against JDBC endpoint
-    jdbc_endpoint = fetch_jdbc_endpoint(juju)
     assert run_sql_test_against_jdbc_endpoint(
         juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
     assert is_entire_cluster_responding_requests(
-        juju, test_pod=test_pod, username=username, password=password
+        juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
 
 

--- a/tests/integration/test_ha.py
+++ b/tests/integration/test_ha.py
@@ -17,8 +17,7 @@ from core.domain import Status
 from .helpers import (
     delete_pod,
     deploy_minimal_kyuubi_setup,
-    fetch_jdbc_endpoint,
-    fetch_password,
+    fetch_connection_info,
     get_active_kyuubi_servers_list,
     get_kyuubi_pid,
     is_entire_cluster_responding_requests,
@@ -51,12 +50,14 @@ def test_build_and_deploy_cluster_with_no_zookeeper(
     juju.wait(jubilant.all_active, delay=10)
 
 
-def test_standalone_kyuubi_works_without_zookeeper(juju: jubilant.Juju, test_pod: str) -> None:
-    username = "admin"
-    password = fetch_password(juju)
+def test_standalone_kyuubi_works_without_zookeeper(
+    juju: jubilant.Juju, test_pod: str, charm_versions: IntegrationTestsCharms
+) -> None:
+    jdbc_endpoint, username, password = fetch_connection_info(
+        juju, charm_versions.data_integrator.app
+    )
 
     # Run SQL tests against JDBC endpoint
-    jdbc_endpoint = fetch_jdbc_endpoint(juju)
     assert run_sql_test_against_jdbc_endpoint(
         juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
@@ -101,18 +102,18 @@ def test_zookeeper_relation_with_three_units_of_kyuubi(
     assert set(active_servers) == set(expected_servers)
 
     # Run SQL test against the cluster
-    username = "admin"
-    password = fetch_password(juju)
+    jdbc_endpoint, username, password = fetch_connection_info(
+        juju, charm_versions.data_integrator.app
+    )
 
     # Run SQL tests against JDBC endpoint
-    jdbc_endpoint = fetch_jdbc_endpoint(juju)
     assert run_sql_test_against_jdbc_endpoint(
         juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
 
     # Assert the entire cluster is usable
     assert is_entire_cluster_responding_requests(
-        juju, test_pod, username=username, password=password
+        juju, test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
 
 
@@ -142,18 +143,18 @@ def test_pod_reschedule(
     assert len(active_servers) == 3
 
     # Run SQL test against the cluster
-    username = "admin"
-    password = fetch_password(juju)
+    jdbc_endpoint, username, password = fetch_connection_info(
+        juju, charm_versions.data_integrator.app
+    )
 
     # Run SQL tests against JDBC endpoint
-    jdbc_endpoint = fetch_jdbc_endpoint(juju)
     assert run_sql_test_against_jdbc_endpoint(
         juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
 
     # Assert the entire cluster is usable
     assert is_entire_cluster_responding_requests(
-        juju, test_pod, username=username, password=password
+        juju, test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
 
 
@@ -194,18 +195,18 @@ def test_kill_kyuubi_process(
     assert len(active_servers) == 3
 
     # Run SQL test against the cluster
-    username = "admin"
-    password = fetch_password(juju)
+    jdbc_endpoint, username, password = fetch_connection_info(
+        juju, charm_versions.data_integrator.app
+    )
 
     # Run SQL tests against JDBC endpoint
-    jdbc_endpoint = fetch_jdbc_endpoint(juju)
     assert run_sql_test_against_jdbc_endpoint(
         juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
 
     # Assert the entire cluster is usable
     assert is_entire_cluster_responding_requests(
-        juju, test_pod, username=username, password=password
+        juju, test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
 
 
@@ -228,18 +229,18 @@ def test_scale_down_kyuubi_from_three_to_two_with_zookeeper(
     assert len(active_servers) == 2
 
     # Run SQL test against the cluster
-    username = "admin"
-    password = fetch_password(juju)
+    jdbc_endpoint, username, password = fetch_connection_info(
+        juju, charm_versions.data_integrator.app
+    )
 
     # Run SQL tests against JDBC endpoint
-    jdbc_endpoint = fetch_jdbc_endpoint(juju)
     assert run_sql_test_against_jdbc_endpoint(
         juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
 
     # Assert the entire cluster is usable
     assert is_entire_cluster_responding_requests(
-        juju, test_pod, username=username, password=password
+        juju, test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
 
 
@@ -261,18 +262,18 @@ def test_scale_down_to_standalone_kyuubi_with_zookeeper(
     assert len(active_servers) == 1
 
     # Run SQL test against the cluster
-    username = "admin"
-    password = fetch_password(juju)
+    jdbc_endpoint, username, password = fetch_connection_info(
+        juju, charm_versions.data_integrator.app
+    )
 
     # Run SQL tests against JDBC endpoint
-    jdbc_endpoint = fetch_jdbc_endpoint(juju)
     assert run_sql_test_against_jdbc_endpoint(
         juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
 
     # Assert the entire cluster is usable
     assert is_entire_cluster_responding_requests(
-        juju, test_pod, username=username, password=password
+        juju, test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )
 
 
@@ -290,11 +291,11 @@ def test_remove_zookeeper_relation_on_single_unit(
     )
 
     # Run SQL test against the cluster
-    username = "admin"
-    password = fetch_password(juju)
+    jdbc_endpoint, username, password = fetch_connection_info(
+        juju, charm_versions.data_integrator.app
+    )
 
     # Run SQL tests against JDBC endpoint
-    jdbc_endpoint = fetch_jdbc_endpoint(juju)
     assert run_sql_test_against_jdbc_endpoint(
         juju, test_pod=test_pod, jdbc_endpoint=jdbc_endpoint, username=username, password=password
     )

--- a/tests/integration/test_iceberg.py
+++ b/tests/integration/test_iceberg.py
@@ -11,7 +11,7 @@ from spark_test.core.kyuubi import KyuubiClient
 
 from .helpers import (
     deploy_minimal_kyuubi_setup,
-    fetch_password,
+    fetch_connection_info,
     get_leader_unit,
 )
 from .types import IntegrationTestsCharms, S3Info
@@ -41,14 +41,15 @@ def test_deploy_kyuubi_setup(
     juju.wait(jubilant.all_active, delay=5)
 
 
-def test_iceberg_with_iceberg_catalog(juju: jubilant.Juju) -> None:
+def test_iceberg_with_iceberg_catalog(
+    juju: jubilant.Juju, charm_versions: IntegrationTestsCharms
+) -> None:
     """Test Iceberg capabilities using the `iceberg` catalog created by default."""
     status = juju.status()
     leader = get_leader_unit(juju, APP_NAME)
     host = status.apps[APP_NAME].units[leader].address
     port = 10009
-    username = "admin"
-    password = fetch_password(juju)
+    _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
 
     # Put some load by executing some Kyuubi SQL queries
     kyuubi_client = KyuubiClient(host=host, port=port, username=username, password=password)
@@ -84,8 +85,7 @@ def test_iceberg_external_metastore(
     leader = get_leader_unit(juju, APP_NAME)
     host = status.apps[APP_NAME].units[leader].address
     port = 10009
-    username = "admin"
-    password = fetch_password(juju)
+    _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
 
     kyuubi_client = KyuubiClient(host=host, port=port, username=username, password=password)
 
@@ -119,8 +119,7 @@ def test_disconnect_and_reconnect_external_metastore(
     leader = get_leader_unit(juju, APP_NAME)
     host = status.apps[APP_NAME].units[leader].address
     port = 10009
-    username = "admin"
-    password = fetch_password(juju)
+    _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
 
     kyuubi_client = KyuubiClient(host=host, port=port, username=username, password=password)
 
@@ -134,14 +133,15 @@ def test_disconnect_and_reconnect_external_metastore(
 
 
 # Test normal tables can be written / read using the iceberg catalog
-def test_normal_table_format_with_iceberg_catalog(juju: jubilant.Juju) -> None:
+def test_normal_table_format_with_iceberg_catalog(
+    juju: jubilant.Juju, charm_versions: IntegrationTestsCharms
+) -> None:
     """Test that tables using non-iceberg format can be read and written using iceberg catalog."""
     status = juju.status()
     leader = get_leader_unit(juju, APP_NAME)
     host = status.apps[APP_NAME].units[leader].address
     port = 10009
-    username = "admin"
-    password = fetch_password(juju)
+    _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
 
     kyuubi_client = KyuubiClient(host=host, port=port, username=username, password=password)
 
@@ -157,7 +157,9 @@ def test_normal_table_format_with_iceberg_catalog(juju: jubilant.Juju) -> None:
         assert len(results) == 1
 
 
-def test_iceberg_with_spark_catalog(juju: jubilant.Juju) -> None:
+def test_iceberg_with_spark_catalog(
+    juju: jubilant.Juju, charm_versions: IntegrationTestsCharms
+) -> None:
     """Test running Kyuubi SQL queries when dynamic allocation option is disabled in Kyuubi charm."""
     logger.info("Changing Iceberg catalog to default spark_catalog...")
     juju.config(APP_NAME, {"iceberg-catalog-name": "spark_catalog"})
@@ -167,8 +169,7 @@ def test_iceberg_with_spark_catalog(juju: jubilant.Juju) -> None:
     leader = get_leader_unit(juju, APP_NAME)
     host = status.apps[APP_NAME].units[leader].address
     port = 10009
-    username = "admin"
-    password = fetch_password(juju)
+    _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
 
     # Put some load by executing some Kyuubi SQL queries
     kyuubi_client = KyuubiClient(host=host, port=port, username=username, password=password)
@@ -184,14 +185,15 @@ def test_iceberg_with_spark_catalog(juju: jubilant.Juju) -> None:
         assert len(results) == 1
 
 
-def test_reading_table_written_by_other_catalog(juju: jubilant.Juju) -> None:
+def test_reading_table_written_by_other_catalog(
+    juju: jubilant.Juju, charm_versions: IntegrationTestsCharms
+) -> None:
     """Test whether one is able to read data written using iceberg catalog using spark_catalog."""
     status = juju.status()
     leader = get_leader_unit(juju, APP_NAME)
     host = status.apps[APP_NAME].units[leader].address
     port = 10009
-    username = "admin"
-    password = fetch_password(juju)
+    _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
 
     kyuubi_client = KyuubiClient(host=host, port=port, username=username, password=password)
 
@@ -204,14 +206,15 @@ def test_reading_table_written_by_other_catalog(juju: jubilant.Juju) -> None:
         assert len(results) == 1
 
 
-def test_normal_table_format_with_iceberg_enabled_spark_catalog(juju: jubilant.Juju) -> None:
+def test_normal_table_format_with_iceberg_enabled_spark_catalog(
+    juju: jubilant.Juju, charm_versions: IntegrationTestsCharms
+) -> None:
     """Test that tables using non-iceberg format can be read and written using iceberg enabled spark_catalog."""
     status = juju.status()
     leader = get_leader_unit(juju, APP_NAME)
     host = status.apps[APP_NAME].units[leader].address
     port = 10009
-    username = "admin"
-    password = fetch_password(juju)
+    _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
 
     kyuubi_client = KyuubiClient(host=host, port=port, username=username, password=password)
 

--- a/tests/integration/test_metastore.py
+++ b/tests/integration/test_metastore.py
@@ -15,7 +15,7 @@ from core.domain import Status
 
 from .helpers import (
     deploy_minimal_kyuubi_setup,
-    fetch_password,
+    fetch_connection_info,
     validate_sql_queries_with_kyuubi,
 )
 from .types import IntegrationTestsCharms, S3Info
@@ -49,10 +49,11 @@ def test_deploy_minimal_kyuubi_setup(
     juju.wait(jubilant.all_active, delay=15)
 
 
-def test_sql_queries_local_metastore(juju: jubilant.Juju) -> None:
+def test_sql_queries_local_metastore(
+    juju: jubilant.Juju, charm_versions: IntegrationTestsCharms
+) -> None:
     """Test running SQL queries without an external metastore."""
-    username = "admin"
-    password = fetch_password(juju)
+    _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
     assert validate_sql_queries_with_kyuubi(
         juju=juju,
         username=username,
@@ -103,10 +104,11 @@ def test_integrate_external_metastore(
         assert cursor.rowcount == 1
 
 
-def test_sql_queries_external_metastore(juju: jubilant.Juju) -> None:
+def test_sql_queries_external_metastore(
+    juju: jubilant.Juju, charm_versions: IntegrationTestsCharms
+) -> None:
     """Test running SQL queries with an external metastore."""
-    username = "admin"
-    password = fetch_password(juju)
+    _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
     assert validate_sql_queries_with_kyuubi(
         juju=juju,
         db_name=TEST_EXTERNAL_DB_NAME,
@@ -149,14 +151,15 @@ def test_remove_external_metastore(
         assert cursor.rowcount == 1
 
 
-def test_run_sql_queries_again_with_local_metastore(juju: jubilant.Juju) -> None:
+def test_run_sql_queries_again_with_local_metastore(
+    juju: jubilant.Juju, charm_versions: IntegrationTestsCharms
+) -> None:
     """Test running SQL queries again with local metastore."""
     logger.info(
         "Waiting for extra 30 seconds as cool-down period before proceeding with the test..."
     )
     time.sleep(30)
-    username = "admin"
-    password = fetch_password(juju)
+    _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
     assert validate_sql_queries_with_kyuubi(
         juju=juju,
         username=username,
@@ -260,10 +263,11 @@ def test_integrate_metastore_with_valid_schema_again(
     assert status.apps[INVALID_METASTORE_APP_NAME].app_status.current == "active"
 
 
-def test_read_write_with_valid_schema_metastore_again(juju: jubilant.Juju) -> None:
+def test_read_write_with_valid_schema_metastore_again(
+    juju: jubilant.Juju, charm_versions: IntegrationTestsCharms
+) -> None:
     """Test whether previously written data can be read as well as new data can be written."""
-    username = "admin"
-    password = fetch_password(juju)
+    _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
     assert validate_sql_queries_with_kyuubi(
         juju=juju,
         username=username,

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -12,7 +12,7 @@ from tenacity import Retrying, stop_after_attempt, wait_fixed
 from .helpers import (
     all_prometheus_exporters_data,
     deploy_minimal_kyuubi_setup,
-    fetch_password,
+    fetch_connection_info,
     get_cos_address,
     published_grafana_dashboards,
     published_loki_logs,
@@ -51,10 +51,9 @@ def test_build_and_deploy(
     juju.wait(jubilant.all_active, delay=15)
 
 
-def test_run_some_sql_queries(juju: jubilant.Juju) -> None:
+def test_run_some_sql_queries(juju: jubilant.Juju, charm_versions: IntegrationTestsCharms) -> None:
     """Test running SQL queries without an external metastore."""
-    username = "admin"
-    password = fetch_password(juju)
+    _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
 
     assert validate_sql_queries_with_kyuubi(juju=juju, username=username, password=password)
 

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -85,7 +85,7 @@ def test_kyuubi_client_relation_joined(
         cursor.execute(""" SELECT username, passwd FROM kyuubi_users WHERE username <> 'admin' """)
         num_users = cursor.rowcount
 
-    assert num_users == 0
+    assert num_users == 1  # data-integrator
 
     logger.info("Integrating test charm with kyuubi-k8s charm...")
     juju.integrate(APP_NAME, TEST_CHARM_NAME)
@@ -105,10 +105,10 @@ def test_kyuubi_client_relation_joined(
         # Fetch number of users excluding the default admin user
         cursor.execute(""" SELECT username, passwd FROM kyuubi_users WHERE username <> 'admin' """)
         num_users = cursor.rowcount
-        kyuubi_username, kyuubi_password = cursor.fetchone()  # type: ignore
+        kyuubi_username, kyuubi_password = cursor.fetchall()[-1]  # type: ignore
 
     # A new user has indeed been created
-    assert num_users != 0
+    assert num_users != 1
 
     logger.info(f"Relation user's username: {kyuubi_username} and password: {kyuubi_password}")
 
@@ -143,10 +143,10 @@ def test_kyuubi_client_relation_removed(
         # Fetch number of users excluding the default admin user
         cursor.execute(""" SELECT username, passwd FROM kyuubi_users WHERE username <> 'admin' """)
         num_users_before = cursor.rowcount
-        kyuubi_username, kyuubi_password = cursor.fetchone()  # type: ignore
+        kyuubi_username, kyuubi_password = cursor.fetchall()[-1]  # type: ignore
 
     logger.info(f"Relation user's username: {kyuubi_username} and password: {kyuubi_password}")
-    assert num_users_before != 0
+    assert num_users_before != 1
 
     assert validate_sql_queries_with_kyuubi(
         juju=juju, username=kyuubi_username, password=kyuubi_password
@@ -175,7 +175,7 @@ def test_kyuubi_client_relation_removed(
         num_users_after = cursor.rowcount
 
     # Assert that relation user created previously has been deleted
-    assert num_users_after == 0
+    assert num_users_after == 1  # data-integrator
 
     with pytest.raises(TTransportException) as exc:
         validate_sql_queries_with_kyuubi(

--- a/tests/integration/types.py
+++ b/tests/integration/types.py
@@ -64,3 +64,4 @@ class IntegrationTestsCharms(BaseModel):
     integration_hub: TestCharm
     zookeeper: TestCharm
     tls: TestCharm
+    data_integrator: TestCharm

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -46,9 +46,7 @@ def ctx() -> Context:
     return ctx
 
 
-@pytest.mark.parametrize(
-    ["action"], [("get-password",), ("set-password",), ("get-jdbc-endpoint",)]
-)
+@pytest.mark.parametrize(["action"], [("get-password",), ("set-password",)])
 def test_action_not_leader(action: str, ctx: Context, base_state: State) -> None:
     # Given
     state_in = dataclasses.replace(base_state, leader=False)
@@ -74,9 +72,7 @@ def test_password_action_not_related(ctx: Context, base_state: State, action: st
     assert "The action can only be run when authentication is enabled" in exc_info.value.message
 
 
-@pytest.mark.parametrize(
-    ["action"], [("get-password",), ("set-password",), ("get-jdbc-endpoint",)]
-)
+@pytest.mark.parametrize(["action"], [("get-password",), ("set-password",)])
 def test_action_workload_not_ready(ctx: Context, action: str) -> None:
     # Given
     relation_db = Relation(
@@ -103,9 +99,7 @@ def test_action_workload_not_ready(ctx: Context, action: str) -> None:
     assert exc_info.value.message == "The action failed because the workload is not ready yet."
 
 
-@pytest.mark.parametrize(
-    ["action"], [("get-password",), ("set-password",), ("get-jdbc-endpoint",)]
-)
+@pytest.mark.parametrize(["action"], [("get-password",), ("set-password",)])
 def test_action_workload_not_active(ctx: Context, base_state: State, action: str) -> None:
     # Given
     relation_db = Relation(


### PR DESCRIPTION
# Changes

- This PR removes the `get-jdbc-endpoint` action and replace it with an integration with data-integrator in the tests where we previously relied on it
- While doing so, I noticed that we were not updating related clients in case of enabling TLS or changing the service. This is now fixed for LB. I created a ticket for properly enabling nodeport, as we have no support for the moment in the existing client provider logic

TODO after merging: change the quick start guide on discourse