### PR TITLE
[DPE-7686] Set application port

### DIFF
--- a/src/events/kyuubi.py
+++ b/src/events/kyuubi.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, cast
 import ops
 from ops import SecretChangedEvent
 
-from constants import DEFAULT_ADMIN_USERNAME, PEER_REL
+from constants import DEFAULT_ADMIN_USERNAME, JDBC_PORT, PEER_REL
 from core.context import Context
 from core.domain import DatabaseConnectionInfo
 from core.workload.kyuubi import KyuubiWorkload
@@ -154,6 +154,7 @@ class KyuubiEvents(BaseEventHandler, WithLogging):
     def _on_kyuubi_pebble_ready(self, _: ops.PebbleReadyEvent):
         """Define and start a workload using the Pebble API."""
         self.logger.info("Kyuubi pebble service is ready.")
+        self.charm.unit.set_ports(JDBC_PORT)
         self.kyuubi.update()
 
     def _on_peer_relation_joined(self, _: ops.RelationJoinedEvent):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,9 +7,9 @@ import logging
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-from ops.testing import Container, Context, Relation, State
+from ops.testing import Container, Context, Relation, State, TCPPort
 
-from constants import JOB_OCI_IMAGE, KYUUBI_CONTAINER_NAME
+from constants import JDBC_PORT, JOB_OCI_IMAGE, KYUUBI_CONTAINER_NAME
 from core.domain import Status
 from managers.service import Endpoint
 
@@ -57,6 +57,7 @@ def test_pebble_ready(
     )
     out = kyuubi_context.run(kyuubi_context.on.pebble_ready(kyuubi_container), state)
     assert out.unit_status == Status.MISSING_INTEGRATION_HUB.value
+    assert out.opened_ports == {TCPPort(JDBC_PORT)}
 
 
 @patch("managers.k8s.K8sManager.is_namespace_valid", return_value=True)


### PR DESCRIPTION
## Changes

- Address #102 


Notes: I tried various setups, but the port column in `juju status` is always empty on my end, no matter the charm. This PR does change the port listed in the k8s service.

Before (charm from latest/edge)
```
kubectl get svc -n test
NAME                            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)              AGE
kyuubi-k8s                      ClusterIP   10.152.183.69    <none>        65535/TCP            5m3s
...
```

This PR:
```
kubectl get svc -n test
NAME                            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)              AGE
...
local-no-expose                 ClusterIP   10.152.183.251   <none>        10009/TCP            96s
```

See that the service correctly shows 10009

@gustavosr98 Though this does not show the port in `juju status` (at least on my end on both microk8s and k8s models), does that PR answer your need?