### PR TITLE
[DPE-7941] Add GPU support

### DIFF
--- a/.github/workflows/ci-gpu.yaml
+++ b/.github/workflows/ci-gpu.yaml
@@ -92,60 +92,35 @@ jobs:
 
       - name: Install required packages/snaps
         run: |
-          sudo systemctl stop unattended-upgrades
-          sudo apt-get update
-          sudo apt-get install build-essential tox python3-dev libpq-dev -yqq
-          sudo snap install yq
-          sudo snap install juju --channel 3.6/stable
-          sudo snap install microk8s --channel 1.32/stable --classic
+          systemctl disable unattended-upgrades
+          systemctl stop unattended-upgrades
+          apt purge unattended-upgrades -y
+          apt update
+          apt install build-essential python3-dev libpq-dev -yqq pipx
+          snap install yq
+          snap install juju --channel 3.6/stable
+          snap install microk8s --channel 1.32/stable --classic
+          snap alias microk8s.kubectl kubectl
+          usermod -aG microk8s ubuntu
 
-      - name: Configure microk8s
+      - name: Configure user, microk8s and juju
         run: |
-          sudo microk8s status --wait-ready
-          sudo snap alias microk8s.kubectl kubectl
-          mkdir -p /home/ubuntu/.kube
-          sudo chown -f -R ubuntu /home/ubuntu/.kube
-          sudo microk8s config | tee /home/ubuntu/.kube/config
-          sudo microk8s enable hostpath-storage dns rbac nvidia
-          sudo microk8s status --wait-ready
-
-      - name: Setup environment
-        run: |
-          juju add-k8s mk8s --client
-          juju bootstrap mk8s mk8s
-
-      # - name: Setup tmate session
-      #   if: ${{ failure() }}
-      #   uses: mxschmitt/action-tmate@v3
-      #   timeout-minutes: 20
+          su ubuntu -c "/bin/bash ./tests/integration/setup/setup-ec2-gpu.sh"
+        timeout-minutes: 20
 
       - name: Download packed charm(s)
         uses: actions/download-artifact@v5
         with:
           artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
           merge-multiple: true
-
-      - name: Select tests
-        id: select-tests
-        run: |
-          if [ "${{ github.event_name }}" == "schedule" ]
-          then
-            echo Running unstable and stable tests
-            echo "mark_expression=" >> $GITHUB_OUTPUT
-          else
-            echo Skipping unstable tests
-            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
-          fi
+          path: /home/ubuntu/workdir
 
       - name: Run integration tests
-        run: tox run -e integration-gpu -- -m '${{ steps.select-tests.outputs.mark_expression }}'
-        env:
-          CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
-
-      # - name: Setup tmate session
-      #   if: ${{ failure() }}
-      #   uses: mxschmitt/action-tmate@v3
-      #   timeout-minutes: 20
+        run: |
+          mv ./** /home/ubuntu/workdir
+          chown -R ubuntu /home/ubuntu
+          cd /home/ubuntu/workdir
+          su ubuntu -c "~/.local/bin/tox run -e integration-gpu"
 
   stop-runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/ci-gpu.yaml
+++ b/.github/workflows/ci-gpu.yaml
@@ -97,7 +97,7 @@ jobs:
           sudo apt-get install build-essential tox python3-dev libpq-dev -yqq
           sudo snap install yq
           sudo snap install juju --channel 3.6/stable
-          sudo snap install microk8s --channel 1.32/stable
+          sudo snap install microk8s --channel 1.32/stable --classic
 
       - name: Configure microk8s
         run: |

--- a/.github/workflows/ci-gpu.yaml
+++ b/.github/workflows/ci-gpu.yaml
@@ -1,0 +1,170 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: GPU Tests
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+  schedule:
+    - cron: "53 0 * * *" # Daily at 00:53 UTC
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Install tox
+        run: pipx install tox
+      - name: Run linters
+        run: tox run -e lint
+
+  unit-test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Install tox
+        run: pipx install tox
+      - name: Run tests
+        run: tox run -e unit
+
+  build:
+    strategy:
+      matrix:
+        path:
+          - .
+    name: Build charm | ${{ matrix.path }}
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v32.0.0
+    with:
+      path-to-charm-directory: ${{ matrix.path }}
+
+  start-runner:
+    name: Start self-hosted EC2 runner
+    needs: [build]
+    runs-on: ubuntu-22.04
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@v2.4.1
+        with:
+          mode: start
+          github-token: ${{ secrets.WELPAOLO_GITHUB_TOKEN }}
+          ec2-image-id: ${{ vars.AWS_EC2_IMAGE_ID }}
+          ec2-instance-type: ${{ vars.AWS_EC2_INSTANCE_TYPE }}
+          subnet-id: ${{ vars.AWS_DEFAULT_SUBNET_ID }}
+          security-group-id: ${{ vars.AWS_SECURITY_GROUP_ID }}
+
+  integration-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-environments:
+          - integration-charm
+    name: ${{ matrix.tox-environments }}
+    needs:
+      - lint
+      - unit-test
+      - build
+      - start-runner
+    runs-on: ${{ needs.start-runner.outputs.label }}
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install required packages/snaps
+        run: |
+          sudo systemctl stop unattended-upgrades
+          sudo apt-get update
+          sudo apt-get install build-essential tox python3-dev libpq-dev -yqq
+          sudo snap install yq
+          sudo snap install juju --channel 3.6/stable
+          sudo snap install microk8s --channel 1.32/stable
+
+      - name: Configure microk8s
+        run: |
+          sudo microk8s status --wait-ready
+          sudo snap alias microk8s.kubectl kubectl
+          mkdir -p /home/ubuntu/.kube
+          sudo chown -f -R ubuntu /home/ubuntu/.kube
+          sudo microk8s config | tee /home/ubuntu/.kube/config
+          sudo microk8s enable hostpath-storage dns rbac nvidia
+          sudo microk8s status --wait-ready
+
+      - name: Setup environment
+        run: |
+          juju add-k8s mk8s --client
+          juju bootstrap mk8s mk8s
+
+      # - name: Setup tmate session
+      #   if: ${{ failure() }}
+      #   uses: mxschmitt/action-tmate@v3
+      #   timeout-minutes: 20
+
+      - name: Download packed charm(s)
+        uses: actions/download-artifact@v5
+        with:
+          artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
+          merge-multiple: true
+
+      - name: Select tests
+        id: select-tests
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]
+          then
+            echo Running unstable and stable tests
+            echo "mark_expression=" >> $GITHUB_OUTPUT
+          else
+            echo Skipping unstable tests
+            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run integration tests
+        run: tox run -e integration-gpu -- -m '${{ steps.select-tests.outputs.mark_expression }}'
+        env:
+          CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
+
+      # - name: Setup tmate session
+      #   if: ${{ failure() }}
+      #   uses: mxschmitt/action-tmate@v3
+      #   timeout-minutes: 20
+
+  stop-runner:
+    name: Stop self-hosted EC2 runner
+    needs:
+      - start-runner
+      - integration-test
+    runs-on: ubuntu-22.04
+    if: ${{ always() }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@v2.4.1
+        with:
+          mode: stop
+          github-token: ${{ secrets.WELPAOLO_GITHUB_TOKEN }}
+          label: ${{ needs.start-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}

--- a/config.yaml
+++ b/config.yaml
@@ -18,26 +18,6 @@ options:
     description: Enable dynamic allocation of pods for Spark jobs.
     default: false
 
-  enable-gpu:
-    type: boolean
-    description: |
-      Enable GPU acceleration for the SparkSQLEngine.
-      This option override 'enable-dynamic-allocation' toggling auto-scaling for executor pods.
-      Is equivalent to the following Spark configuration:
-
-      spark.plugins=com.nvidia.spark.SQLPlugin
-      spark.executor.resource.gpu.amount=1
-      spark.executor.resource.gpu.vendor=nvidia.com
-      spark.kubernetes.container.image=GPU_JOB_OCI_IMAGE
-      spark.executor.resource.gpu.discoveryScript=/opt/getGpusResources.sh
-      kyuubi.session.engine.idle.timeout=PT3M
-      spark.rapids.memory.pinnedPool.size=1G
-      spark.executor.memoryOverhead=1G
-      spark.task.resource.gpu.amount=0.5
-      spark.rapids.sql.concurrentGpuTasks=2
-
-    default: false
-
   executor-cores:
     type: int
     description: |
@@ -70,11 +50,31 @@ options:
     description: The mode in which the service should be exposed externally. Valid values are false, nodeport and loadbalancer.
     default: "false"
 
+  gpu-enable:
+    type: boolean
+    description: |
+      Enable GPU acceleration for the SparkSQLEngine.
+      This option override 'enable-dynamic-allocation' toggling auto-scaling for executor pods.
+      Is equivalent to the following Spark configuration:
+
+      spark.plugins=com.nvidia.spark.SQLPlugin
+      spark.executor.resource.gpu.amount=1
+      spark.executor.resource.gpu.vendor=nvidia.com
+      spark.kubernetes.container.image=GPU_JOB_OCI_IMAGE
+      spark.executor.resource.gpu.discoveryScript=/opt/getGpusResources.sh
+      kyuubi.session.engine.idle.timeout=PT3M
+      spark.rapids.memory.pinnedPool.size=1G
+      spark.executor.memoryOverhead=1G
+      spark.task.resource.gpu.amount=0.5
+      spark.rapids.sql.concurrentGpuTasks=2
+
+    default: false
+
   gpu-engine-executors-limit:
     type: int
     description: |
       Limit the number of GPUs an engine can schedule executor pods on. If 0, use all GPUs available. The more tenants are expected, the less this value should be.
-      This option is ignored if 'enable-gpu' is set to false.
+      This option is ignored if 'gpu-enable' is set to false.
       Is equivalent to the following Spark configuration:
 
       spark.executor.instances=1

--- a/config.yaml
+++ b/config.yaml
@@ -2,55 +2,90 @@
 # See LICENSE file for licensing details.
 
 options:
-  namespace:
+  driver-pod-template:
     type: string
-    description: The namespace to be used by driver to create executor pods. If not configured, the model namespace will be used.
+    description: |
+      Define K8s driver pod from a file accessible to the workload.
+      Ex.: "s3a://bucket/template.yml".
+      Is equivalent to the following Spark configuration:
+
+      spark.kubernetes.driver.podTemplateFile=<driver-pod-template>
+
     default: ""
-  service-account:
-    type: string
-    description: The service account to be used by driver to create executor pods.
-    default: "kyuubi-spark-engine"
-  expose-external:
-    type: string
-    description: The mode in which the service should be exposed externally. Valid values are false, nodeport and loadbalancer.
-    default: "false"
-  loadbalancer-extra-annotations:
-    type: string
-    description: Optional extra annotations to be supplied to the load balancer service.
-    default: "{}"
+
   enable-dynamic-allocation:
     type: boolean
     description: Enable dynamic allocation of pods for Spark jobs.
     default: false
+
+  enable-gpu:
+    type: boolean
+    description: |
+      Enable GPU acceleration for the SparkSQLEngine.
+      This option override 'enable-dynamic-allocation' toggling auto-scaling for executor pods.
+      Is equivalent to the following Spark configuration:
+
+      spark.plugins=com.nvidia.spark.SQLPlugin
+      spark.executor.resource.gpu.amount=1
+      spark.executor.resource.gpu.vendor=nvidia.com
+      spark.kubernetes.container.image=GPU_JOB_OCI_IMAGE
+      spark.executor.resource.gpu.discoveryScript=/opt/getGpusResources.sh
+      kyuubi.session.engine.idle.timeout=PT3M
+      spark.rapids.memory.pinnedPool.size=1G
+      spark.executor.memoryOverhead=1G
+      spark.task.resource.gpu.amount=0.5
+      spark.rapids.sql.concurrentGpuTasks=2
+
+    default: false
+
+  executor-cores:
+    type: int
+    description: |
+      Set K8s executor pods cpu limit.
+      Is equivalent to the following Spark configuration:
+
+      spark.executor.cores=4
+
+  executor-memory:
+    type: int
+    description: |
+      Set K8s executor pods memory limit (in GB).
+      Is equivalent to the following Spark configuration:
+
+      spark.executor.memory=4G
+
+  executor-pod-template:
+    type: string
+    description: |
+      Define K8s executor pods from a file accessible to the workload.
+      Ex.: "s3a://bucket/template.yml".
+      Is equivalent to the following Spark configuration:
+
+      spark.kubernetes.executor.podTemplateFile=<executor-pod-template>
+
+    default: ""
+
+  expose-external:
+    type: string
+    description: The mode in which the service should be exposed externally. Valid values are false, nodeport and loadbalancer.
+    default: "false"
+
+  gpu-engine-executors-limit:
+    type: int
+    description: |
+      Limit the number of GPUs an engine can schedule executor pods on. If 0, use all GPUs available. The more tenants are expected, the less this value should be.
+      This option is ignored if 'enable-gpu' is set to false.
+      Is equivalent to the following Spark configuration:
+
+      spark.executor.instances=1
+
+    default: 1
+
   iceberg-catalog-name:
     type: string
     description: The name of the catalog that has Iceberg capabilities.
     default: iceberg
-  system-users:
-    type: secret
-    description: |
-      Configure the system user 'admin' and it's password. This needs to be a Juju secret URI pointing to a secret that contains the
-      following content: `admin: <password>`. If this config option is not provided, the charm will generate a random password for the
-      admin user.
-  tls-client-private-key:
-    type: secret
-    description: |
-      A Juju secret URI of a secret containing the private key for client-to-server TLS certificates. This needs to be a Juju secret
-      URI pointing to a secret that has the content { private-key: <key> }, where <key> is the key to be used by the charm to generate
-      Certificate Signing Request (CSR). If this config option is not provided, the charm will generate a new private key and use it instead.
-  pause-after-unit-refresh:
-    description: |
-      Wait for manual confirmation to resume refresh after these units refresh
 
-      Allowed values: "all", "first", "none"
-    type: string
-    default: first
-  profile:
-    description: |
-      Profile representing the scope of the deployment, and used to enable high-level customization of system configurations, resource checks/allocation, warning levels, etc.
-      Allowed values are: "production", "staging" and "testing"
-    type: string
-    default: production
   k8s-node-selectors:
     type: string
     description: |
@@ -63,3 +98,47 @@ options:
 
       The desired configuration will be applied for both driver and executor pods.
     default: ""
+
+  loadbalancer-extra-annotations:
+    type: string
+    description: Optional extra annotations to be supplied to the load balancer service.
+    default: "{}"
+
+  namespace:
+    type: string
+    description: The namespace to be used by driver to create executor pods. If not configured, the model namespace will be used.
+    default: ""
+
+  pause-after-unit-refresh:
+    description: |
+      Wait for manual confirmation to resume refresh after these units refresh
+
+      Allowed values: "all", "first", "none"
+    type: string
+    default: first
+
+  profile:
+    description: |
+      Profile representing the scope of the deployment, and used to enable high-level customization of system configurations, resource checks/allocation, warning levels, etc.
+      Allowed values are: "production", "staging" and "testing"
+    type: string
+    default: production
+
+  service-account:
+    type: string
+    description: The service account to be used by driver to create executor pods.
+    default: "kyuubi-spark-engine"
+
+  system-users:
+    type: secret
+    description: |
+      Configure the system user 'admin' and it's password. This needs to be a Juju secret URI pointing to a secret that contains the
+      following content: `admin: <password>`. If this config option is not provided, the charm will generate a random password for the
+      admin user.
+
+  tls-client-private-key:
+    type: secret
+    description: |
+      A Juju secret URI of a secret containing the private key for client-to-server TLS certificates. This needs to be a Juju secret
+      URI pointing to a secret that has the content { private-key: <key> }, where <key> is the key to be used by the charm to generate
+      Certificate Signing Request (CSR). If this config option is not provided, the charm will generate a new private key and use it instead.

--- a/config.yaml
+++ b/config.yaml
@@ -81,6 +81,19 @@ options:
 
     default: 1
 
+  gpu-pinned-memory:
+    type: int
+    description: |
+      Set the host memory (in GB) per executor reserved for fast data transfer on GPUs.
+      This also sets the executor memory overhead to be 1GB larger.
+      This option is ignored if 'gpu-enable' is set to false.
+      Is equivalent to the following Spark configuration:
+
+      spark.rapids.memory.pinnedPool.size=1G
+      spark.executor.memoryOverhead=2G  # 1 + 1
+
+    default: 1
+
   iceberg-catalog-name:
     type: string
     description: The name of the catalog that has Iceberg capabilities.

--- a/config.yaml
+++ b/config.yaml
@@ -63,17 +63,14 @@ options:
       spark.kubernetes.container.image=GPU_JOB_OCI_IMAGE
       spark.executor.resource.gpu.discoveryScript=/opt/getGpusResources.sh
       kyuubi.session.engine.idle.timeout=PT3M
-      spark.rapids.memory.pinnedPool.size=1G
-      spark.executor.memoryOverhead=1G
-      spark.task.resource.gpu.amount=0.5
-      spark.rapids.sql.concurrentGpuTasks=2
 
     default: false
 
   gpu-engine-executors-limit:
     type: int
     description: |
-      Limit the number of GPUs an engine can schedule executor pods on. If 0, use all GPUs available. The more tenants are expected, the less this value should be.
+      Limit the number of GPUs an engine can schedule executor pods on. If -1, use all GPUs available. The more tenants are expected, the less this value should be.
+      This option should be set to either -1 or a positive integer.
       This option is ignored if 'gpu-enable' is set to false.
       Is equivalent to the following Spark configuration:
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,8 +34,8 @@ resources:
   kyuubi-image:
     type: oci-image
     description: OCI image for kyuubi
-    # spark-3.4.4, kyuubi 1.10.2 release date 25/07/25
-    upstream-source: ghcr.io/canonical/charmed-spark-kyuubi@sha256:38f35ce47b84b8370da9a371edaf83ca9911347a1efd6eb0cfbc8128f051b1e4
+    # spark-3.4.4, kyuubi 1.10.2 release date 08/09/25
+    upstream-source: ghcr.io/canonical/charmed-spark-kyuubi@sha256:229edcdfd45156aa19e99395842fdba7c2bbe02d7d4dc0c7cd65123cadf55fb3
 
 peers:
   kyuubi-peers:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,8 +34,8 @@ resources:
   kyuubi-image:
     type: oci-image
     description: OCI image for kyuubi
-    # spark-3.4.4, kyuubi 1.10.2 release date 08/09/25
-    upstream-source: ghcr.io/canonical/charmed-spark-kyuubi@sha256:229edcdfd45156aa19e99395842fdba7c2bbe02d7d4dc0c7cd65123cadf55fb3
+    # spark-3.4.4, kyuubi 1.10.2 release date 11/09/25
+    upstream-source: ghcr.io/canonical/charmed-spark-kyuubi@sha256:c284924ff55152adc9a60000939d6ec604ec156ef4f4f9c9af90ef2cc501b1de
 
 peers:
   kyuubi-peers:

--- a/src/charm.py
+++ b/src/charm.py
@@ -207,6 +207,17 @@ class KyuubiCharm(TypedCharmBase[CharmConfig]):
         if not k8s_manager.is_service_account_valid():
             statuses.append(Status.INVALID_SERVICE_ACCOUNT.value)
 
+        if self.config.enable_gpu and not k8s_manager.get_number_of_gpus():
+            statuses.append(Status.GPU_NOT_FOUND.value)
+
+        if (
+            self.config.enable_gpu
+            and k8s_manager.is_executor_pod_template_configured()
+            and not self.config.executor_pod_template
+        ):
+            # Executor pod template defined in integration hub
+            statuses.append(Status.MISSING_EXEC_POD_TEMPLATE.value)
+
         if not self.context.auth_db:
             statuses.append(Status.MISSING_AUTH_DB.value)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -207,11 +207,11 @@ class KyuubiCharm(TypedCharmBase[CharmConfig]):
         if not k8s_manager.is_service_account_valid():
             statuses.append(Status.INVALID_SERVICE_ACCOUNT.value)
 
-        if self.config.enable_gpu and not k8s_manager.get_number_of_gpus():
+        if self.config.gpu_enable and not k8s_manager.get_number_of_gpus():
             statuses.append(Status.GPU_NOT_FOUND.value)
 
         if (
-            self.config.enable_gpu
+            self.config.gpu_enable
             and k8s_manager.is_executor_pod_template_configured()
             and not self.config.executor_pod_template
         ):

--- a/src/charm.py
+++ b/src/charm.py
@@ -218,6 +218,12 @@ class KyuubiCharm(TypedCharmBase[CharmConfig]):
             # Executor pod template defined in integration hub
             statuses.append(Status.MISSING_EXEC_POD_TEMPLATE.value)
 
+        if (
+            self.config.gpu_enable
+            and k8s_manager.get_number_of_gpus() < self.config.gpu_engine_executors_limit
+        ):
+            statuses.append(Status.NOT_ENOUGH_GPUS.value)
+
         if not self.context.auth_db:
             statuses.append(Status.MISSING_AUTH_DB.value)
 

--- a/src/config/kyuubi.py
+++ b/src/config/kyuubi.py
@@ -62,6 +62,13 @@ class KyuubiConfig(WithLogging):
                     "kyuubi.session.engine.idle.timeout": "PT3M",
                 }
             )
+
+        if self.charm_config.profile == "testing":
+            conf.update(
+                {
+                    "kyuubi.session.engine.idle.timeout": "PT1M",
+                }
+            )
         return conf
 
     @property

--- a/src/config/kyuubi.py
+++ b/src/config/kyuubi.py
@@ -56,7 +56,7 @@ class KyuubiConfig(WithLogging):
             "kyuubi.session.engine.initialize.timeout": "PT10M",
         }
 
-        if self.charm_config.enable_gpu:
+        if self.charm_config.gpu_enable:
             conf.update(
                 {
                     "kyuubi.session.engine.idle.timeout": "PT3M",

--- a/src/config/kyuubi.py
+++ b/src/config/kyuubi.py
@@ -6,6 +6,7 @@
 """Kyuubi workload configurations."""
 
 from constants import AUTHENTICATION_TABLE_NAME
+from core.config import CharmConfig
 from core.domain import DatabaseConnectionInfo, TLSInfo, ZookeeperInfo
 from utils.logging import WithLogging
 
@@ -15,11 +16,13 @@ class KyuubiConfig(WithLogging):
 
     def __init__(
         self,
+        charm_config: CharmConfig,
         db_info: DatabaseConnectionInfo | None,
         zookeeper_info: ZookeeperInfo | None,
         tls_info: TLSInfo | None,
         keystore_path: str,
     ):
+        self.charm_config = charm_config
         self.db_info = db_info
         self.zookeeper_info = zookeeper_info
         self.tls = tls_info
@@ -52,6 +55,13 @@ class KyuubiConfig(WithLogging):
         conf = {
             "kyuubi.session.engine.initialize.timeout": "PT10M",
         }
+
+        if self.charm_config.enable_gpu:
+            conf.update(
+                {
+                    "kyuubi.session.engine.idle.timeout": "PT3M",
+                }
+            )
         return conf
 
     @property

--- a/src/config/spark.py
+++ b/src/config/spark.py
@@ -69,15 +69,13 @@ class SparkConfig(WithLogging):
                     "spark.executor.instances": str(
                         self.charm_config.gpu_engine_executors_limit or self.gpu_capacity
                     ),
-                    "spark.executor.memoryOverhead": "1G",
+                    "spark.executor.memoryOverhead": f"{self.charm_config.gpu_pinned_memory + 1}G",
                     "spark.executor.resource.gpu.amount": "1",
                     "spark.executor.resource.gpu.discoveryScript": "/opt/getGpusResources.sh",
                     "spark.executor.resource.gpu.vendor": "nvidia.com",
                     "spark.kubernetes.container.image": GPU_JOB_OCI_IMAGE,
                     "spark.plugins": "com.nvidia.spark.SQLPlugin",
-                    "spark.rapids.memory.pinnedPool.size": "1G",
-                    "spark.rapids.sql.concurrentGpuTasks": "2",
-                    "spark.task.resource.gpu.amount": "0.5",
+                    "spark.rapids.memory.pinnedPool.size": f"{self.charm_config.gpu_pinned_memory}G",
                 }
             )
             if ept:

--- a/src/config/spark.py
+++ b/src/config/spark.py
@@ -41,7 +41,7 @@ class SparkConfig(WithLogging):
             "spark.submit.deployMode": "cluster",
         }
 
-        if self.charm_config.enable_dynamic_allocation and not self.charm_config.enable_gpu:
+        if self.charm_config.enable_dynamic_allocation and not self.charm_config.gpu_enable:
             conf.update(
                 {
                     "spark.dynamicAllocation.enabled": "true",
@@ -63,7 +63,7 @@ class SparkConfig(WithLogging):
                 }
             )
 
-        if self.charm_config.enable_gpu:
+        if self.charm_config.gpu_enable:
             conf.update(
                 {
                     "spark.executor.instances": str(

--- a/src/config/spark.py
+++ b/src/config/spark.py
@@ -67,7 +67,9 @@ class SparkConfig(WithLogging):
             conf.update(
                 {
                     "spark.executor.instances": str(
-                        self.charm_config.gpu_engine_executors_limit or self.gpu_capacity
+                        self.charm_config.gpu_engine_executors_limit
+                        if self.charm_config.gpu_engine_executors_limit != -1
+                        else self.gpu_capacity
                     ),
                     "spark.executor.memoryOverhead": f"{self.charm_config.gpu_pinned_memory + 1}G",
                     "spark.executor.resource.gpu.amount": "1",

--- a/src/config/spark.py
+++ b/src/config/spark.py
@@ -10,6 +10,7 @@ from lightkube import Client
 from constants import GPU_JOB_OCI_IMAGE, JOB_OCI_IMAGE, SPARK_DEFAULT_CATALOG_NAME
 from core.config import CharmConfig
 from core.domain import DatabaseConnectionInfo, SparkServiceAccountInfo
+from core.workload.kyuubi import SPARK_CONF_PATH
 from utils.logging import WithLogging
 
 
@@ -21,10 +22,12 @@ class SparkConfig(WithLogging):
         charm_config: CharmConfig,
         service_account_info: SparkServiceAccountInfo | None,
         metastore_db_info: DatabaseConnectionInfo | None,
+        gpu_capacity: int,
     ):
         self.charm_config = charm_config
         self.service_account_info = service_account_info
         self.metastore_db_info = metastore_db_info
+        self.gpu_capacity = gpu_capacity
 
     def _get_spark_master(self) -> str:
         cluster_address = Client().config.cluster.server
@@ -46,24 +49,6 @@ class SparkConfig(WithLogging):
                 }
             )
 
-        if self.charm_config.enable_gpu:
-            conf.update(
-                {
-                    "spark.executor.instances": str(
-                        self.charm_config.gpu_engine_executors_limit
-                    ),  # TODO: all gpus
-                    "spark.executor.memoryOverhead": "1G",
-                    "spark.executor.resource.gpu.amount": "1",
-                    "spark.executor.resource.gpu.discoveryScript": "/opt/getGpusResources.sh",
-                    "spark.executor.resource.gpu.vendor": "nvidia.com",
-                    "spark.kubernetes.container.image": GPU_JOB_OCI_IMAGE,
-                    "spark.plugins": "com.nvidia.spark.SQLPlugin",
-                    "spark.rapids.memory.pinnedPool.size": "1G",
-                    "spark.rapids.sql.concurrentGpuTasks": "2",
-                    "spark.task.resource.gpu.amount": "0.5",
-                }
-            )
-
         if dpt := self.charm_config.driver_pod_template:
             conf.update(
                 {
@@ -77,6 +62,34 @@ class SparkConfig(WithLogging):
                     "spark.kubernetes.executor.podTemplateFile": ept,
                 }
             )
+
+        if self.charm_config.enable_gpu:
+            conf.update(
+                {
+                    "spark.executor.instances": str(
+                        self.charm_config.gpu_engine_executors_limit or self.gpu_capacity
+                    ),
+                    "spark.executor.memoryOverhead": "1G",
+                    "spark.executor.resource.gpu.amount": "1",
+                    "spark.executor.resource.gpu.discoveryScript": "/opt/getGpusResources.sh",
+                    "spark.executor.resource.gpu.vendor": "nvidia.com",
+                    "spark.kubernetes.container.image": GPU_JOB_OCI_IMAGE,
+                    "spark.plugins": "com.nvidia.spark.SQLPlugin",
+                    "spark.rapids.memory.pinnedPool.size": "1G",
+                    "spark.rapids.sql.concurrentGpuTasks": "2",
+                    "spark.task.resource.gpu.amount": "0.5",
+                }
+            )
+            if ept:
+                self.logger.info(
+                    "'executor-pod-template' option used, make sure that gpu limits are properly set."
+                )
+            else:
+                conf.update(
+                    {
+                        "spark.kubernetes.executor.podTemplateFile": f"{SPARK_CONF_PATH}/gpu_executor_template.yaml",
+                    }
+                )
 
         if e_cores := self.charm_config.executor_cores:
             conf.update(
@@ -101,12 +114,12 @@ class SparkConfig(WithLogging):
             )
 
         if self.charm_config.k8s_node_selectors:
-            for k, v in self.charm_config.k8s_node_selectors.items():
-                conf.update(
-                    {
-                        f"spark.kubernetes.node.selector.{k}": v,
-                    }
-                )
+            conf.update(
+                {
+                    f"spark.kubernetes.node.selector.{k}": v
+                    for k, v in self.charm_config.k8s_node_selectors.items()
+                }
+            )
         return conf
 
     def _sa_conf(self) -> dict[str, str]:

--- a/src/config/spark.py
+++ b/src/config/spark.py
@@ -5,11 +5,9 @@
 
 """Spark related configurations."""
 
-from typing import Optional
-
 from lightkube import Client
 
-from constants import JOB_OCI_IMAGE, SPARK_DEFAULT_CATALOG_NAME
+from constants import GPU_JOB_OCI_IMAGE, JOB_OCI_IMAGE, SPARK_DEFAULT_CATALOG_NAME
 from core.config import CharmConfig
 from core.domain import DatabaseConnectionInfo, SparkServiceAccountInfo
 from utils.logging import WithLogging
@@ -21,8 +19,8 @@ class SparkConfig(WithLogging):
     def __init__(
         self,
         charm_config: CharmConfig,
-        service_account_info: Optional[SparkServiceAccountInfo],
-        metastore_db_info: Optional[DatabaseConnectionInfo],
+        service_account_info: SparkServiceAccountInfo | None,
+        metastore_db_info: DatabaseConnectionInfo | None,
     ):
         self.charm_config = charm_config
         self.service_account_info = service_account_info
@@ -32,20 +30,68 @@ class SparkConfig(WithLogging):
         cluster_address = Client().config.cluster.server
         return f"k8s://{cluster_address}"
 
-    def _base_conf(self):
+    def _base_conf(self) -> dict[str, str]:
         """Return base Spark configurations."""
         conf = {
             "spark.master": self._get_spark_master(),
             "spark.kubernetes.container.image": JOB_OCI_IMAGE,
             "spark.submit.deployMode": "cluster",
         }
-        if self.charm_config.enable_dynamic_allocation:
+
+        if self.charm_config.enable_dynamic_allocation and not self.charm_config.enable_gpu:
             conf.update(
                 {
                     "spark.dynamicAllocation.enabled": "true",
                     "spark.dynamicAllocation.shuffleTracking.enabled": "true",
                 }
             )
+
+        if self.charm_config.enable_gpu:
+            conf.update(
+                {
+                    "spark.executor.instances": str(
+                        self.charm_config.gpu_engine_executors_limit
+                    ),  # TODO: all gpus
+                    "spark.executor.memoryOverhead": "1G",
+                    "spark.executor.resource.gpu.amount": "1",
+                    "spark.executor.resource.gpu.discoveryScript": "/opt/getGpusResources.sh",
+                    "spark.executor.resource.gpu.vendor": "nvidia.com",
+                    "spark.kubernetes.container.image": GPU_JOB_OCI_IMAGE,
+                    "spark.plugins": "com.nvidia.spark.SQLPlugin",
+                    "spark.rapids.memory.pinnedPool.size": "1G",
+                    "spark.rapids.sql.concurrentGpuTasks": "2",
+                    "spark.task.resource.gpu.amount": "0.5",
+                }
+            )
+
+        if dpt := self.charm_config.driver_pod_template:
+            conf.update(
+                {
+                    "spark.kubernetes.driver.podTemplateFile": dpt,
+                }
+            )
+
+        if ept := self.charm_config.executor_pod_template:
+            conf.update(
+                {
+                    "spark.kubernetes.executor.podTemplateFile": ept,
+                }
+            )
+
+        if e_cores := self.charm_config.executor_cores:
+            conf.update(
+                {
+                    "spark.executor.cores": str(e_cores),
+                }
+            )
+
+        if e_memory := self.charm_config.executor_memory:
+            conf.update(
+                {
+                    "spark.executor.memory": f"{e_memory}G",
+                }
+            )
+
         if self.charm_config.profile == "testing":
             conf.update(
                 {
@@ -53,6 +99,7 @@ class SparkConfig(WithLogging):
                     "spark.kubernetes.driver.request.cores": "100m",
                 }
             )
+
         if self.charm_config.k8s_node_selectors:
             for k, v in self.charm_config.k8s_node_selectors.items():
                 conf.update(
@@ -62,7 +109,7 @@ class SparkConfig(WithLogging):
                 )
         return conf
 
-    def _sa_conf(self):
+    def _sa_conf(self) -> dict[str, str]:
         """Spark configurations read from Spark8t."""
         if not self.service_account_info:
             return {}
@@ -74,7 +121,7 @@ class SparkConfig(WithLogging):
         conf.update(self.service_account_info.spark_properties)
         return conf
 
-    def _iceberg_conf(self):
+    def _iceberg_conf(self) -> dict[str, str]:
         """Apache iceberg related configurations."""
         sa_conf = self._sa_conf()
         if not sa_conf or not sa_conf.get("spark.sql.warehouse.dir"):

--- a/src/constants.py
+++ b/src/constants.py
@@ -29,10 +29,10 @@ COS_LOG_RELATION_NAME_SERVER = "logging"
 JDBC_PORT = 10009
 SPARK_DEFAULT_CATALOG_NAME = "spark_catalog"
 
-# spark 3.4.4, release date 25/07/2025
-JOB_OCI_IMAGE = "ghcr.io/canonical/charmed-spark@sha256:568d652977b06a1791588ae1b57529c0b32a44641fac7364f4f16cde5f1c18b4"
-# spark-gpu 3.4.4, release date 08/08/2025
-GPU_JOB_OCI_IMAGE = "ghcr.io/canonical/charmed-spark-gpu@sha256:b93f46e6c532d95ab08e047aa16c332d2078f8881ba85bad26e4ba37853c7aa6"
+# spark 3.4.4, release date 08/09/2025
+JOB_OCI_IMAGE = "ghcr.io/canonical/charmed-spark@sha256:9fc65e87f7ac077dad7ca304558006e8adf2d8fbf605e67466fc0894571b2e44"
+# spark-gpu 3.4.4, release date 08/09/2025
+GPU_JOB_OCI_IMAGE = "ghcr.io/canonical/charmed-spark-gpu@sha256:9884472bebe5c77820f17a6e95b882afe3e1475aeb2ff246b2f6d3f56c7ee110"
 
 DEFAULT_ADMIN_USERNAME = "admin"
 PASSWORD_SUFFIX = "-password"

--- a/src/constants.py
+++ b/src/constants.py
@@ -29,10 +29,10 @@ COS_LOG_RELATION_NAME_SERVER = "logging"
 JDBC_PORT = 10009
 SPARK_DEFAULT_CATALOG_NAME = "spark_catalog"
 
-# spark 3.4.4, release date 08/09/2025
-JOB_OCI_IMAGE = "ghcr.io/canonical/charmed-spark@sha256:9fc65e87f7ac077dad7ca304558006e8adf2d8fbf605e67466fc0894571b2e44"
-# spark-gpu 3.4.4, release date 08/09/2025
-GPU_JOB_OCI_IMAGE = "ghcr.io/canonical/charmed-spark-gpu@sha256:9884472bebe5c77820f17a6e95b882afe3e1475aeb2ff246b2f6d3f56c7ee110"
+# spark 3.4.4, release date 11/09/2025
+JOB_OCI_IMAGE = "ghcr.io/canonical/charmed-spark@sha256:c4e9b0a9404e9b5caff24d7937b30f5228da12b1a2c75e6126c4856619f39972"
+# spark-gpu 3.4.4, release date 11/09/2025
+GPU_JOB_OCI_IMAGE = "ghcr.io/canonical/charmed-spark-gpu@sha256:eb8200b96e43584df7d9b49030c74fceef29246b976a6ac11d7412c64765f9f8"
 
 DEFAULT_ADMIN_USERNAME = "admin"
 PASSWORD_SUFFIX = "-password"

--- a/src/constants.py
+++ b/src/constants.py
@@ -31,6 +31,8 @@ SPARK_DEFAULT_CATALOG_NAME = "spark_catalog"
 
 # spark 3.4.4, release date 25/07/2025
 JOB_OCI_IMAGE = "ghcr.io/canonical/charmed-spark@sha256:568d652977b06a1791588ae1b57529c0b32a44641fac7364f4f16cde5f1c18b4"
+# spark-gpu 3.4.4, release date 08/08/2025
+GPU_JOB_OCI_IMAGE = "ghcr.io/canonical/charmed-spark-gpu@sha256:b93f46e6c532d95ab08e047aa16c332d2078f8881ba85bad26e4ba37853c7aa6"
 
 DEFAULT_ADMIN_USERNAME = "admin"
 PASSWORD_SUFFIX = "-password"

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -30,6 +30,7 @@ class CharmConfig(BaseConfigModel):
     expose_external: ExposeExternal
     gpu_enable: bool
     gpu_engine_executors_limit: NonNegativeInt
+    gpu_pinned_memory: NonNegativeInt
     iceberg_catalog_name: str
     k8s_node_selectors: dict[str, str] | None
     loadbalancer_extra_annotations: str

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -31,7 +31,7 @@ class CharmConfig(BaseConfigModel):
     expose_external: ExposeExternal
     gpu_engine_executors_limit: NonNegativeInt
     iceberg_catalog_name: str
-    k8s_node_selectors: str
+    k8s_node_selectors: dict[str, str] | None
     loadbalancer_extra_annotations: str
     namespace: str
     profile: Literal["production", "staging", "testing"]
@@ -39,7 +39,7 @@ class CharmConfig(BaseConfigModel):
     system_users: Optional[str] = Field(pattern=SECRET_REGEX, exclude=True)
     tls_client_private_key: Optional[str] = Field(pattern=SECRET_REGEX, exclude=True)
 
-    @validator("k8s_node_selectors")
+    @validator("k8s_node_selectors", pre=True)
     @classmethod
     def k8s_node_selectors_validator(cls, value: str) -> dict[str, str] | None:
         """Check validity of `k8s_node_selectors` field."""

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -29,7 +29,7 @@ class CharmConfig(BaseConfigModel):
     executor_pod_template: str
     expose_external: ExposeExternal
     gpu_enable: bool
-    gpu_engine_executors_limit: NonNegativeInt
+    gpu_engine_executors_limit: PositiveInt | Literal[-1]
     gpu_pinned_memory: NonNegativeInt
     iceberg_catalog_name: str
     k8s_node_selectors: dict[str, str] | None

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -7,7 +7,7 @@
 
 import logging
 import re
-from typing import Literal, Optional
+from typing import Literal
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
 from pydantic import Field, NonNegativeInt, PositiveInt, validator
@@ -24,11 +24,11 @@ class CharmConfig(BaseConfigModel):
 
     driver_pod_template: str
     enable_dynamic_allocation: bool
-    enable_gpu: bool
     executor_cores: PositiveInt | None
     executor_memory: PositiveInt | None
     executor_pod_template: str
     expose_external: ExposeExternal
+    gpu_enable: bool
     gpu_engine_executors_limit: NonNegativeInt
     iceberg_catalog_name: str
     k8s_node_selectors: dict[str, str] | None
@@ -36,8 +36,8 @@ class CharmConfig(BaseConfigModel):
     namespace: str
     profile: Literal["production", "staging", "testing"]
     service_account: str
-    system_users: Optional[str] = Field(pattern=SECRET_REGEX, exclude=True)
-    tls_client_private_key: Optional[str] = Field(pattern=SECRET_REGEX, exclude=True)
+    system_users: str | None = Field(pattern=SECRET_REGEX, exclude=True)
+    tls_client_private_key: str | None = Field(pattern=SECRET_REGEX, exclude=True)
 
     @validator("k8s_node_selectors", pre=True)
     @classmethod

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -10,7 +10,7 @@ import re
 from typing import Literal, Optional
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
-from pydantic import Field, validator
+from pydantic import Field, NonNegativeInt, PositiveInt, validator
 
 from .enums import ExposeExternal
 
@@ -22,16 +22,22 @@ SECRET_REGEX = re.compile("secret:[a-z0-9]{20}")
 class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration."""
 
-    namespace: str
-    service_account: str
-    expose_external: ExposeExternal
-    loadbalancer_extra_annotations: str
+    driver_pod_template: str
     enable_dynamic_allocation: bool
+    enable_gpu: bool
+    executor_cores: PositiveInt | None
+    executor_memory: PositiveInt | None
+    executor_pod_template: str
+    expose_external: ExposeExternal
+    gpu_engine_executors_limit: NonNegativeInt
     iceberg_catalog_name: str
+    k8s_node_selectors: str
+    loadbalancer_extra_annotations: str
+    namespace: str
+    profile: Literal["production", "staging", "testing"]
+    service_account: str
     system_users: Optional[str] = Field(pattern=SECRET_REGEX, exclude=True)
     tls_client_private_key: Optional[str] = Field(pattern=SECRET_REGEX, exclude=True)
-    profile: Literal["production", "staging", "testing"]
-    k8s_node_selectors: str
 
     @validator("k8s_node_selectors")
     @classmethod

--- a/src/core/domain.py
+++ b/src/core/domain.py
@@ -71,6 +71,7 @@ class Status(Enum):
     )
     NOT_SERVING_REQUESTS = MaintenanceStatus("Kyuubi is not serving requests")
     GPU_NOT_FOUND = BlockedStatus("Cannot find GPU resources")
+    NOT_ENOUGH_GPUS = BlockedStatus("Cannot request more GPU than cluster capacity")
     MISSING_EXEC_POD_TEMPLATE = BlockedStatus("Need 'executor-pod-template' option with GPU limit")
 
     ACTIVE = ActiveStatus("")

--- a/src/core/domain.py
+++ b/src/core/domain.py
@@ -69,8 +69,9 @@ class Status(Enum):
     TLS_SECRET_INVALID = BlockedStatus(
         "Secret provided as tls-client-private-key has invalid content"
     )
-
     NOT_SERVING_REQUESTS = MaintenanceStatus("Kyuubi is not serving requests")
+    GPU_NOT_FOUND = BlockedStatus("Cannot find GPU resources")
+    MISSING_EXEC_POD_TEMPLATE = BlockedStatus("Need 'executor-pod-template' option with GPU limit")
 
     ACTIVE = ActiveStatus("")
 

--- a/src/events/kyuubi.py
+++ b/src/events/kyuubi.py
@@ -84,7 +84,7 @@ spec:
         """
 
         self.workload.write(
-            gpu_template, f"{self.workload.paths.spark_conf_path}/gpu_executor_template"
+            gpu_template, f"{self.workload.paths.spark_conf_path}/gpu_executor_template.yaml"
         )
 
     @defer_when_not_ready

--- a/src/events/kyuubi.py
+++ b/src/events/kyuubi.py
@@ -46,7 +46,6 @@ class KyuubiEvents(BaseEventHandler, WithLogging):
         self.tls_manager = TLSManager(context=self.context, workload=self.workload)
 
         self.framework.observe(self.charm.on.install, self._on_install)
-        self.framework.observe(self.charm.on.start, self._on_start)
         self.framework.observe(self.charm.on.upgrade_charm, self._on_kyuubi_upgrade)
         self.framework.observe(self.charm.on.kyuubi_pebble_ready, self._on_kyuubi_pebble_ready)
         self.framework.observe(self.charm.on.update_status, self._update_event)
@@ -66,25 +65,6 @@ class KyuubiEvents(BaseEventHandler, WithLogging):
 
     def _on_install(self, _: ops.InstallEvent) -> None:
         """Handle the `on_install` event."""
-
-    @defer_when_not_ready
-    def _on_start(self, _: ops.StartEvent) -> None:
-        """Handle the `on_start` event."""
-        # FIXME: Remove once it's part of the OCI resource itself
-        gpu_template = """
-apiVersion: v1
-kind: Pod
-spec:
-  containers:
-    - name: executor
-      resources:
-        limits:
-          nvidia.com/gpu: 1
-        """
-
-        self.workload.write(
-            gpu_template, f"{self.workload.paths.spark_conf_path}/gpu_executor_template.yaml"
-        )
 
     @defer_when_not_ready
     def _on_kyuubi_upgrade(self, event: ops.UpgradeCharmEvent) -> None:

--- a/src/events/kyuubi.py
+++ b/src/events/kyuubi.py
@@ -75,7 +75,6 @@ class KyuubiEvents(BaseEventHandler, WithLogging):
 apiVersion: v1
 kind: Pod
 spec:
-  ttlSecondsAfterFinished: 300
   containers:
     - name: executor
       resources:

--- a/src/events/kyuubi.py
+++ b/src/events/kyuubi.py
@@ -46,6 +46,7 @@ class KyuubiEvents(BaseEventHandler, WithLogging):
         self.tls_manager = TLSManager(context=self.context, workload=self.workload)
 
         self.framework.observe(self.charm.on.install, self._on_install)
+        self.framework.observe(self.charm.on.start, self._on_start)
         self.framework.observe(self.charm.on.upgrade_charm, self._on_kyuubi_upgrade)
         self.framework.observe(self.charm.on.kyuubi_pebble_ready, self._on_kyuubi_pebble_ready)
         self.framework.observe(self.charm.on.update_status, self._update_event)
@@ -65,6 +66,26 @@ class KyuubiEvents(BaseEventHandler, WithLogging):
 
     def _on_install(self, _: ops.InstallEvent) -> None:
         """Handle the `on_install` event."""
+
+    @defer_when_not_ready
+    def _on_start(self, _: ops.StartEvent) -> None:
+        """Handle the `on_start` event."""
+        # FIXME: Remove once it's part of the OCI resource itself
+        gpu_template = """
+apiVersion: v1
+kind: Pod
+spec:
+  ttlSecondsAfterFinished: 300
+  containers:
+    - name: executor
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+        """
+
+        self.workload.write(
+            gpu_template, f"{self.workload.paths.spark_conf_path}/gpu_executor_template"
+        )
 
     @defer_when_not_ready
     def _on_kyuubi_upgrade(self, event: ops.UpgradeCharmEvent) -> None:

--- a/src/managers/k8s.py
+++ b/src/managers/k8s.py
@@ -65,5 +65,5 @@ class K8sManager(WithLogging):
         """Get the total number of GPUs across all nodes."""
         n_gpus = 0
         for node in Client().list(Node):
-            n_gpus += getattr(getattr(node.status, "capacity", None), "nvidia.com/gpu", 0)
+            n_gpus += int(getattr(node.status, "capacity", {}).get("nvidia.com/gpu", 0))
         return n_gpus

--- a/src/managers/k8s.py
+++ b/src/managers/k8s.py
@@ -9,7 +9,7 @@ import re
 
 from lightkube import Client
 from lightkube.core.exceptions import ApiError
-from lightkube.resources.core_v1 import Namespace, ServiceAccount
+from lightkube.resources.core_v1 import Namespace, Node, ServiceAccount
 
 from core.domain import SparkServiceAccountInfo
 from core.workload.kyuubi import KyuubiWorkloadBase
@@ -55,3 +55,15 @@ class K8sManager(WithLogging):
         """Return whether Azure object storage backend has been configured."""
         pattern = r"spark\.hadoop\.fs\.azure\.account\.key\..*\.dfs\.core\.windows\.net$"
         return any(re.match(pattern, prop) for prop in self.spark_properties)
+
+    def is_executor_pod_template_configured(self) -> bool:
+        """Return whether executor pod template has been configured."""
+        pattern = r"spark\.kubernetes\.executor\.podTemplateFile$"
+        return any(re.match(pattern, prop) for prop in self.spark_properties)
+
+    def get_number_of_gpus(self) -> int:
+        """Get the total number of GPUs across all nodes."""
+        n_gpus = 0
+        for node in Client().list(Node):
+            n_gpus += getattr(getattr(node.status, "capacity", None), "nvidia.com/gpu", 0)
+        return n_gpus

--- a/src/managers/kyuubi.py
+++ b/src/managers/kyuubi.py
@@ -86,6 +86,7 @@ class KyuubiManager(WithLogging):
                 ),
                 self._compare_and_update_file(
                     KyuubiConfig(
+                        charm_config=self.context.config,
                         db_info=auth_db_info,
                         zookeeper_info=zookeeper_info,
                         tls_info=tls_info,

--- a/src/managers/kyuubi.py
+++ b/src/managers/kyuubi.py
@@ -13,6 +13,7 @@ from config.kyuubi import KyuubiConfig
 from config.spark import SparkConfig
 from core.context import Context
 from core.workload.kyuubi import KyuubiWorkload
+from managers.k8s import K8sManager
 from utils.logging import WithLogging
 
 if TYPE_CHECKING:
@@ -69,6 +70,15 @@ class KyuubiManager(WithLogging):
         zookeeper_info = None if set_zookeeper_none else self.context.zookeeper
         tls_info = None if set_tls_none else self.context.tls
 
+        if self.context.config.enable_gpu and self.context.service_account:
+            k8s_manager = K8sManager(
+                service_account_info=self.context.service_account,
+                workload=self.workload,
+            )
+            gpu_capacity = k8s_manager.get_number_of_gpus()
+        else:
+            gpu_capacity = 0
+
         # Restart workload only if some configuration has changed.
         should_restart = any(
             [
@@ -77,6 +87,7 @@ class KyuubiManager(WithLogging):
                         charm_config=self.context.config,
                         service_account_info=service_account_info,
                         metastore_db_info=metastore_db_info,
+                        gpu_capacity=gpu_capacity,
                     ).contents,
                     self.workload.paths.spark_properties,
                 ),

--- a/src/managers/kyuubi.py
+++ b/src/managers/kyuubi.py
@@ -70,7 +70,7 @@ class KyuubiManager(WithLogging):
         zookeeper_info = None if set_zookeeper_none else self.context.zookeeper
         tls_info = None if set_tls_none else self.context.tls
 
-        if self.context.config.enable_gpu and self.context.service_account:
+        if self.context.config.gpu_enable and self.context.service_account:
             k8s_manager = K8sManager(
                 service_account_info=self.context.service_account,
                 workload=self.workload,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -58,15 +58,15 @@ def charm_versions() -> IntegrationTestsCharms:
     return IntegrationTestsCharms(
         s3=TestCharm(
             name="s3-integrator",
-            channel="edge",
-            revision=41,
+            channel="1/stable",
+            revision=145,
             base="ubuntu@22.04",
             alias="s3",
         ),
         metastore_db=TestCharm(
             name="postgresql-k8s",
             channel="14/stable",
-            revision=281,
+            revision=495,
             base="ubuntu@22.04",
             alias="metastore",
             trust=True,
@@ -74,15 +74,15 @@ def charm_versions() -> IntegrationTestsCharms:
         auth_db=TestCharm(
             name="postgresql-k8s",
             channel="14/stable",
-            revision=281,
+            revision=495,
             base="ubuntu@22.04",
             alias="auth-db",
             trust=True,
         ),
         integration_hub=TestCharm(
             name="spark-integration-hub-k8s",
-            channel="latest/edge",
-            revision=43,
+            channel="3/stable",
+            revision=67,
             base="ubuntu@22.04",
             alias="integration-hub",
             trust=True,
@@ -96,8 +96,8 @@ def charm_versions() -> IntegrationTestsCharms:
         ),
         tls=TestCharm(
             name="self-signed-certificates",
-            channel="latest/stable",
-            revision=163,  # FIXME (certs): Unpin the revision once the charm is fixed
+            channel="1/stable",
+            revision=317,
             base="ubuntu@22.04",
             alias="self-signed-certificates",
         ),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -112,7 +112,8 @@ def charm_versions() -> IntegrationTestsCharms:
 
 
 @pytest.fixture(scope="module")
-def s3_bucket_and_creds():
+def s3_bucket_and_creds(request: pytest.FixtureRequest):
+    keep_models = bool(request.config.getoption("--keep-models"))
     logger.info("Fetching S3 credentials from minio.....")
 
     fetch_s3_output = (
@@ -163,12 +164,13 @@ def s3_bucket_and_creds():
         "path": TEST_PATH_NAME,
     }
 
-    logger.info("Tearing down test bucket...")
-    for obj in test_bucket.objects.all():
-        # We need to iterate over keys because delete_objects (plural) has mandatory checksum
-        obj.delete()
+    if not keep_models:
+        logger.info("Tearing down test bucket...")
+        for obj in test_bucket.objects.all():
+            # We need to iterate over keys because delete_objects (plural) has mandatory checksum
+            obj.delete()
 
-    test_bucket.delete()
+        test_bucket.delete()
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -98,7 +98,7 @@ def charm_versions() -> IntegrationTestsCharms:
             name="self-signed-certificates",
             channel="1/stable",
             revision=317,
-            base="ubuntu@22.04",
+            base="ubuntu@24.04",
             alias="self-signed-certificates",
         ),
         data_integrator=TestCharm(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -665,6 +665,13 @@ def run_command_in_pod(
     return stdout, stderr
 
 
+def get_pod_logs(juju: jubilant.Juju, pod_name: str) -> str:
+    """Get logs from pod."""
+    client = lightkube.Client()
+    lines = client.log(pod_name, namespace=cast(str, juju.model))
+    return "".join(lines)
+
+
 def umask_named_temporary_file(*args, **kargs):
     """Return a temporary file descriptor readable by all users."""
     file_desc = NamedTemporaryFile(*args, **kargs)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -527,14 +527,6 @@ def deploy_minimal_kyuubi_setup(
         )
     )
 
-    # Add configuration key to prevent resource starvation during tests
-    task = juju.run(
-        f"{charm_versions.integration_hub.app}/0",
-        "add-config",
-        {"conf": "spark.kubernetes.executor.request.cores=0.1"},
-    )
-    assert task.return_code == 0
-
     logger.info("Integrating integration-hub charm with s3-integrator charm...")
     juju.integrate(charm_versions.s3.app, charm_versions.integration_hub.app)
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -657,13 +657,6 @@ def run_command_in_pod(
     return stdout, stderr
 
 
-def get_pod_logs(juju: jubilant.Juju, pod_name: str) -> str:
-    """Get logs from pod."""
-    client = lightkube.Client()
-    lines = client.log(pod_name, namespace=cast(str, juju.model))
-    return "".join(lines)
-
-
 def umask_named_temporary_file(*args, **kargs):
     """Return a temporary file descriptor readable by all users."""
     file_desc = NamedTemporaryFile(*args, **kargs)

--- a/tests/integration/setup/setup-ec2-gpu.sh
+++ b/tests/integration/setup/setup-ec2-gpu.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -x
+
+pipx install tox
+pipx ensurepath
+sudo microk8s status --wait-ready
+mkdir ~/.kube
+mkdir ~/workdir
+sudo microk8s config > ~/.kube/config
+sudo microk8s enable hostpath-storage dns rbac nvidia minio
+sudo microk8s status --wait-ready
+
+while ! sudo microk8s.kubectl logs -n gpu-operator-resources -l app=nvidia-operator-validator | grep "all validations are successful"
+do
+  echo "------------------------------------------------------------------------------------------"
+  echo "waiting for validations"
+  sudo microk8s.kubectl get pods -A
+  sudo microk8s.kubectl logs -n kube-system -l k8s-app=hostpath-provisioner
+  sudo microk8s.kubectl describe pod -n gpu-operator-resources nvidia-operator-validator
+  sudo microk8s.status
+  sleep 60
+  echo "------------------------------------------------------------------------------------------"
+done
+
+
+mkdir -p ~/.local/share/juju
+juju add-k8s mk8s --client
+juju bootstrap mk8s mk8s
+
+set +x

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -196,38 +196,10 @@ def test_integration_hub_realtime_updates(
     )
     juju.wait(jubilant.all_active, delay=5)
 
-    # Add a property via integration hub
-    task = juju.run(
-        f"{charm_versions.integration_hub.app}/0",
-        "add-config",
-        {"conf": "foo=bar"},
-    )
-    assert task.return_code == 0
-
     logger.info(
         "Waiting for kyuubi, integration_hub and s3-integrator charms to be idle and active..."
     )
     juju.wait(jubilant.all_active, delay=5)
-
-    props = fetch_spark_properties(juju, unit_name=f"{APP_NAME}/0")
-    assert "foo" in props
-    assert props["foo"] == "bar"
-
-    # Remove the property via integration hub
-    task = juju.run(
-        f"{charm_versions.integration_hub.app}/0",
-        "remove-config",
-        {"key": "foo"},
-    )
-    assert task.return_code == 0
-
-    logger.info(
-        "Waiting for kyuubi, integration_hub and s3-integrator charms to be idle and active..."
-    )
-    juju.wait(jubilant.all_active, delay=5)
-
-    props = fetch_spark_properties(juju, unit_name=f"{APP_NAME}/0")
-    assert "foo" not in props
 
 
 def test_relate_data_integrator(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -13,7 +13,6 @@ from core.domain import Status
 
 from .helpers import (
     fetch_connection_info,
-    fetch_spark_properties,
     validate_sql_queries_with_kyuubi,
 )
 from .types import IntegrationTestsCharms, S3Info

--- a/tests/integration/test_gpu.py
+++ b/tests/integration/test_gpu.py
@@ -3,20 +3,20 @@
 # See LICENSE file for licensing details.
 
 
+import json
 import logging
 from pathlib import Path
 from typing import cast
 
 import jubilant
 import yaml
-from spark_test.utils import get_spark_executors
+from spark_test.utils import LightKubePod, get_spark_drivers, get_spark_executors
 
 from core.domain import Status
 
 from .helpers import (
     deploy_minimal_kyuubi_setup,
     fetch_connection_info,
-    get_pod_logs,
     validate_sql_queries_with_kyuubi,
 )
 from .types import IntegrationTestsCharms, S3Info
@@ -64,19 +64,34 @@ def test_deploy_kyuubi_setup(
 
 
 def test_gpu_used_for_query(juju: jubilant.Juju, charm_versions: IntegrationTestsCharms) -> None:
+    """Check that the GPU resource is used by the executor pod, but not by the driver."""
     _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
     assert validate_sql_queries_with_kyuubi(juju, username=username, password=password)
 
+    # The test plan should have spawn one driver and one executor
     executor_pods = get_spark_executors(namespace=cast(str, juju.model))
+    driver_pods = get_spark_drivers(namespace=cast(str, juju.model))
     assert len(executor_pods) == 1
+    assert len(driver_pods) == 1
 
-    exec_pod = executor_pods[0].pod_name
-    logs = get_pod_logs(juju, exec_pod)
-
+    # The executor pod should request a GPU resource, and the RAPIDS plugin needs to be present
+    # in its logs.
+    exec_pod = executor_pods[0]
+    pod_obj = exec_pod.client.get(
+        LightKubePod, name=exec_pod.pod_name, namespace=exec_pod.namespace
+    ).to_dict()
+    assert "nvidia.com/gpu" in json.dumps(pod_obj)
     assert (
         "ExecutorPluginContainer: Initialized executor component for plugin com.nvidia.spark.SQLPlugin"
-        in logs
+        in "".join(exec_pod.logs())
     )
+
+    # The driver pod should not have requested a GPU resource
+    driver_pod = driver_pods[0]
+    pod_obj = driver_pod.client.get(
+        LightKubePod, name=driver_pod.pod_name, namespace=driver_pod.namespace
+    ).to_dict()
+    assert "nvidia.com/gpu" not in json.dumps(pod_obj)
 
 
 def test_request_more_gpu_than_capacity(juju: jubilant.Juju) -> None:

--- a/tests/integration/test_gpu.py
+++ b/tests/integration/test_gpu.py
@@ -11,6 +11,8 @@ import jubilant
 import yaml
 from spark_test.utils import get_spark_executors
 
+from core.domain import Status
+
 from .helpers import (
     deploy_minimal_kyuubi_setup,
     fetch_connection_info,
@@ -75,3 +77,9 @@ def test_gpu_used_for_query(juju: jubilant.Juju, charm_versions: IntegrationTest
         "ExecutorPluginContainer: Initialized executor component for plugin com.nvidia.spark.SQLPlugin"
         in logs
     )
+
+
+def test_request_more_gpu_than_capacity(juju: jubilant.Juju) -> None:
+    juju.config(APP_NAME, {"gpu-engine-executors-limit": 99})
+    status = juju.wait(lambda status: jubilant.all_blocked(status, APP_NAME), delay=5, timeout=500)
+    assert status.apps[APP_NAME].app_status.message == Status.NOT_ENOUGH_GPUS.value.message

--- a/tests/integration/test_gpu.py
+++ b/tests/integration/test_gpu.py
@@ -57,7 +57,7 @@ def test_deploy_kyuubi_setup(
     juju.wait(jubilant.all_active, delay=20, timeout=1000)
 
     logger.info("Enabling GPU support")
-    juju.config(APP_NAME, {"enable-gpu": True, "gpu-engine-executors-limit": 1})
+    juju.config(APP_NAME, {"gpu-enable": True, "gpu-engine-executors-limit": 1})
     juju.wait(jubilant.all_active, delay=5)
 
 

--- a/tests/integration/test_gpu.py
+++ b/tests/integration/test_gpu.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Limited
+# See LICENSE file for licensing details.
+
+
+import logging
+from pathlib import Path
+from typing import cast
+
+import jubilant
+import yaml
+from spark_test.utils import get_spark_executors
+
+from .helpers import (
+    deploy_minimal_kyuubi_setup,
+    fetch_connection_info,
+    get_pod_logs,
+    validate_sql_queries_with_kyuubi,
+)
+from .types import IntegrationTestsCharms, S3Info
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+APP_NAME = METADATA["name"]
+
+
+def test_deploy_kyuubi_setup(
+    juju: jubilant.Juju,
+    kyuubi_charm: Path,
+    charm_versions: IntegrationTestsCharms,
+    s3_bucket_and_creds: S3Info,
+) -> None:
+    """Deploy the minimal setup for Kyuubi and assert all charms are in active and idle state."""
+    deploy_minimal_kyuubi_setup(
+        juju=juju,
+        kyuubi_charm=kyuubi_charm,
+        charm_versions=charm_versions,
+        s3_bucket_and_creds=s3_bucket_and_creds,
+        trust=True,
+        integrate_zookeeper=True,
+        integrate_data_integrator=True,
+    )
+    # Wait for everything to settle down
+    juju.wait(jubilant.all_active, delay=5)
+
+    logger.info("Deploying postgresql-k8s charm for metastore...")
+    juju.deploy(**charm_versions.metastore_db.deploy_dict())
+
+    logger.info("Waiting for postgresql-k8s and kyuubi-k8s apps to be idle and active...")
+    juju.wait(jubilant.all_active, delay=15, timeout=1000)
+
+    logger.info("Integrating kyuubi-k8s charm with postgresql-k8s charm...")
+    juju.integrate(charm_versions.metastore_db.app, f"{APP_NAME}:metastore-db")
+
+    logger.info("Waiting for postgresql-k8s and kyuubi-k8s charms to be idle...")
+    juju.wait(jubilant.all_active, delay=20, timeout=1000)
+
+    logger.info("Enabling GPU support")
+    juju.config(APP_NAME, {"enable-gpu": True, "gpu-engine-executors-limit": 1})
+    juju.wait(jubilant.all_active, delay=5)
+
+
+def test_gpu_used_for_query(juju: jubilant.Juju, charm_versions: IntegrationTestsCharms) -> None:
+    _, username, password = fetch_connection_info(juju, charm_versions.data_integrator.app)
+    assert validate_sql_queries_with_kyuubi(juju, username=username, password=password)
+
+    executor_pods = get_spark_executors(namespace=cast(str, juju.model))
+    assert len(executor_pods) == 1
+
+    exec_pod = executor_pods[0].pod_name
+    logs = get_pod_logs(juju, exec_pod)
+
+    assert (
+        "ExecutorPluginContainer: Initialized executor component for plugin com.nvidia.spark.SQLPlugin"
+        in logs
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ set_env =
     auth: TESTFILE=test_auth.py
     provider: TESTFILE=test_provider.py
     refresh: TESTFILE=refresh/test_refresh.py
+    gpu: TESTFILE=test_gpu.py
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
@@ -92,7 +93,7 @@ commands =
 
 
 
-[testenv:integration-{charm,trust,ha,upgrade,external-access,tls,dynamic-allocation,observability,iceberg,metastore,auth,provider,refresh}]
+[testenv:integration-{charm,trust,ha,upgrade,external-access,tls,dynamic-allocation,observability,iceberg,metastore,auth,provider,refresh,gpu}]
 description = Run integration tests
 set_env =
     {[testenv]set_env}


### PR DESCRIPTION
This PR adds support for running hardware-accelerated workloads using Apache Kyuubi, following the current state of DA211.

## Changes

- Added the following configuration options
  - gpu-enable
  - gpu-engine-executors-limit
  - gpu-pinned-memory
  - driver-pod-template
  - executor-pod-template
  - executor-cores
  - executor-memory 
- Added a workflow for running a new integration test on an EC2 instance based on #120. We have to move files around and switch users to avoid snap confinement issues. I'm happy to detail why it ended up looking like that.
- The GPU Rock image was missing some jars. I opened https://github.com/canonical/charmed-spark-rock/pull/160 to address this. Once we get a new revision, we need to update the digest here.

## To be done
We settled on having the minimal pod template be part of the Rock image (https://github.com/canonical/charmed-spark-rock/pull/165).
Once it is merged, this PR just needs to:
- Update the OCI digests
- Remove the on-start event handler in `events/kyuubi.py`

Which should be changes trivial enough to not re-request approvals.

