### PR TITLE
[DO NOT MERGE][DPE-5055][DPE-8022] Documentation for GPU support and  monitoring

### DIFF
--- a/docs/how-to/h-enable-gpu.md
+++ b/docs/how-to/h-enable-gpu.md
@@ -1,0 +1,93 @@
+# Enable and configure GPU support for Charmed Apache Kyuubi
+
+Charmed Apache Kyuubi supports the [RAPIDS Accelerator](https://docs.nvidia.com/spark-rapids/index.html) for Apache Spark on K8s.
+This makes possible to run hardware-accelerated queries on NVIDIA GPUs.
+
+## Prerequisites
+
+- Charmed Apache Kyuubi, starting from revision <to-be-filled-once-released> and more.
+- Kubernetes cluster is up and running with NVIDIA GPU support
+
+Check that NVIDIA GPU support is properly enabled by searching for a `gpu-operator` deployment.
+On a non-confined MicroK8s cluster, this is done by enabling the `gpu` [add-on](https://microk8s.io/docs/addon-gpu).
+Once the deployment is successful, you should see a new `gpu-operator-resource` namespace with the following similar-looking pods:
+
+```shell
+kubectl get pods -n gpu-operator-resources
+
+NAME                                                          READY   STATUS
+gpu-feature-discovery-l5g5k                                   1/1     Running
+gpu-operator-85776c76f-7jzp2                                  1/1     Running
+gpu-operator-node-feature-discovery-gc-d8f9f89db-77rz9        1/1     Running 
+gpu-operator-node-feature-discovery-master-79978f78cf-bslkt   1/1     Running 
+gpu-operator-node-feature-discovery-worker-vvg6w              1/1     Running  
+nvidia-container-toolkit-daemonset-r5lq2                      1/1     Running   
+nvidia-cuda-validator-76t6r                                   0/1     Completed  
+nvidia-dcgm-exporter-s92ln                                    1/1     Running    
+nvidia-device-plugin-daemonset-92xnm                          1/1     Running    
+nvidia-operator-validator-d7hhh                               1/1     Running
+```
+
+Finally, make sure that the cluster now list at least one `nvidia.com/gpu` GPU resource under one node's capacity:
+
+```shell
+kubectl get node <node-name> -o=jsonpath="{.status.capacity."nvidia.com/gpu"}"  
+# 1
+```
+
+## Configuring hardware-accelerated spark jobs
+
+Enable hardware-accelerated spark jobs with the following configuration option:
+
+```shell
+juju config <kyuubi-app> gpu-enable=true
+```
+
+Each executor pod will now use one full GPU resource.
+Use the `gpu-engine-executors-limit` to set the number of executors a Kyuubi Engine will spawn.
+
+```shell
+juju config <kyuubi-app> gpu-engine-executors-limit=2
+```
+
+To get the most out of the hardware, it is needed to adapt the pod configuration to the workload:
+
+```shell
+juju config <kyuubi-app> gpu-pinned-memory=4
+juju config <kyuubi-app> executor-memory=8
+juju config <kyuubi-app> executor-cores=4
+```
+
+## Checking that GPU resources are used
+
+If you have a shell access to the machine, you can use the system management interface CLI:
+
+```shell
+nvidia-smi
+```
+
+The output should look like the following
+
+```text
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.169                Driver Version: 570.169        CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  <first GPU unit>               Off |   00000000:01:00.0  On |                  N/A |
+|       .......                           |                        |                  N/A |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A            2611      G   <path to spark process>                XXX MiB |
+|                                          ...                                            |
++-----------------------------------------------------------------------------------------+
+```
+
+Under the `Processes` table, you should see a process for each currently active executor.

--- a/docs/how-to/h-enable-monitoring.md
+++ b/docs/how-to/h-enable-monitoring.md
@@ -1,0 +1,90 @@
+# Enable and configure monitoring for Charmed Apache Kyuubi
+
+Charmed Apache Kyuubi K8s come with the [JMX exporter](https://github.com/prometheus/jmx_exporter/).
+The metrics can be queried by accessing the `http://<kyuubi-unit-ip>:10019/metrics endpoint.
+
+Additionally, Charmed Apache Kyuubi supports native integration with the Canonical Observability Stack (COS).
+
+This section is about monitoring the Apache Kyuubi server, for more information about the underlying Spark jobs and their COS integration, refer to the [COS documentation](https://charmhub.io/topics/canonical-observability-stack) and the [monitoring explanation section](/t/charmed-spark-documentation-explanation-monitoring/14299).
+
+## Integrating with COS
+
+To deploy COS on MicroK8s, follow the [step-by-step tutorial](https://charmhub.io/topics/canonical-observability-stack/tutorials/install-microk8s).
+
+### Offer interfaces via the COS controller
+
+Switch to COS K8s environment and offer COS interfaces to be cross-model integrated with Charmed Apache Kyuubi K8s model:
+
+```shell
+juju switch <k8s_controller>:<cos_model_name>
+
+juju offer grafana:grafana-dashboard grafana-dashboards
+juju offer loki:logging loki-logging
+juju offer prometheus:receive-remote-write prometheus-receive-remote-write
+```
+
+### Consume offers via the Apache Kyuubi model
+
+Switch back to the Charmed Apache Kyuubi K8s model, find offers and integrate with them:
+
+```shell
+juju switch <spark_model_name>
+
+juju find-offers <k8s_controller>:
+```
+
+A similar output should appear, if `k8s` is the K8s controller name and `cos` the model where `cos-lite` has been deployed:
+
+```shell
+Store      URL                                        Access  Interfaces
+k8s        admin/cos.grafana-dashboards               admin   grafana_dashboard:grafana-dashboard
+k8s        admin/cos.loki-logging                     admin   loki_push_api:logging
+k8s        admin/cos.prometheus-receive-remote-write  admin   prometheus-receive-remote-write:receive-remote-write
+...
+```
+
+Consume offers to be reachable in the current model:
+
+```shell
+juju consume <k8s_controller>:admin/<cos_model_name>.prometheus-receive-remote-write
+juju consume <k8s_controller>:admin/<cos_model_name>.loki-logging
+juju consume <k8s_controller>:admin/<cos_model_name>.grafana-dashboards
+```
+
+### Deploy and integrate Grafana agent
+
+Deploy `grafana-agent-k8s`:
+
+```shell
+juju deploy grafana-agent-k8s --trust
+```
+
+Integrate it with consumed COS offers:
+
+```shell
+juju integrate grafana-agent-k8s grafana-dashboards
+juju integrate grafana-agent-k8s loki-logging
+juju integrate grafana-agent-k8s prometheus-receive-remote-write
+```
+
+Finally, integrate `grafana-agent` it with Charmed Apache Kyuubi K8s:
+
+```shell
+juju integrate grafana-agent-k8s kyuubi-k8s:grafana-dashboard
+juju integrate grafana-agent-k8s kyuubi-k8s:logging
+juju integrate grafana-agent-k8s kyuubi-k8s:metrics-endpoint
+```
+
+Wait for all components to settle down to the `active/idle` state on both models.
+
+After this is complete, the monitoring COS stack should be up and running and ready to be used.
+
+### Connect Grafana web interface
+
+To connect to the Grafana web interface, follow the [Browse dashboards](https://charmhub.io/topics/canonical-observability-stack/tutorials/install-microk8s?_ga=2.201254254.1948444620.1704703837-757109492.1701777558#heading--browse-dashboards) section of the MicroK8s "Getting started" guide.
+
+```shell
+juju run grafana/leader get-admin-password --model <k8s_cos_controller>:<cos_model_name>
+```
+
+Then, browse to the **Dashboards** section, where you can find a **Kyuubi** one.


### PR DESCRIPTION
This PR adds two new pieces of documentation:
1. COS monitoring: basically a copy/paste of https://github.com/canonical/spark-history-server-k8s-operator/pull/97. Do we need to add a section about custom alerting rules for Kyuubi? Since we have not defined any yet, I feel like it's a little premature.
2. TBD: GPU support