### PR TITLE
[MISC] Pin juju agent to 3.6.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           juju-channel: 3.6/stable
+          bootstrap-options: "--agent-version 3.6.9"
           provider: microk8s
           channel: 1.32-strict/stable
           microk8s-group: snap_microk8s
@@ -192,6 +193,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           juju-channel: 3.6/stable
+          bootstrap-options: "--agent-version 3.6.9"
           provider: microk8s
           channel: 1.32-strict/stable
           microk8s-group: snap_microk8s

--- a/tests/integration/setup/setup-ec2-gpu.sh
+++ b/tests/integration/setup/setup-ec2-gpu.sh
@@ -26,6 +26,6 @@ done
 
 mkdir -p ~/.local/share/juju
 juju add-k8s mk8s --client
-juju bootstrap mk8s mk8s
+juju bootstrap mk8s mk8s --agent-version=3.6.9
 
 set +x


### PR DESCRIPTION
This PR pins juju agent to 3.6.9 while we figure out what is going on with 3.9.11 and the Integration-hub <-> Kyuubi relation