### PR TITLE
[PRA-75] Set charm version to refresh tag

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -95,9 +95,11 @@ parts:
       write-charm-version
 
       craftctl default
+      grep 'charm =' refresh_versions.toml | cut -d '"' -f 2 > $CRAFT_PART_INSTALL/version
     prime:
       - LICENSE
       - refresh_versions.toml
+      - version
   libpq:
     build-packages:
       - libpq-dev


### PR DESCRIPTION
This PR tinkers with the charm build to add a `version` file to the final archive and sets its content to the refresh tag value, e.g. `v3.5/1.16.0` or equivalent.

This is helpful to get an actual git reference we can use to go back to the code base from a `track/risk`. This version is present in the `juju status` output (only the json or yaml one, not the default table), and **should** be displayed on Charmhub once we release a new revision  (see https://charmhub.io/prometheus-k8s?channel=2/edge to have a look at what it would be like).

Example: `juju status --format yaml`
```yaml
applications:
  test:
    charm: local:kyuubi-k8s-0
    base:
      name: ubuntu
      channel: "22.04"
    charm-origin: local
    charm-name: kyuubi-k8s
    charm-rev: 0
    charm-version: v3.5/1.19.0  # here
```