### PR TITLE
[PRA-156] Enable wheel build cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,8 +45,6 @@ jobs:
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v41.1.0
-    with:
-      cache: false
 
   integration-test:
     strategy:


### PR DESCRIPTION
This PR re-enable the wheel cache in CI after re-triggering a build in charmcraftcache-hub