### PR TITLE
[PRA-76] Renovate configuration to update OCI resources

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,11 +3,7 @@
   "extends": [
     "github>canonical/data-platform//renovate_presets/charm.json5",
   ],
-  "reviewers": [
-    "welpaolo",
-    "theoctober19th",
-    "batalex",
-  ],
+  "reviewers": ["team:processing"],
   // Between 1AM and 6:59AM, first Friday of the month
   "schedule": ["* 1-6 1-7 * 5"],
   "lockFileMaintenance": {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,5 +13,36 @@
   "ignoreDeps": ["ubuntu"],
   "baseBranchPatterns": [
     "/^3\\..*\\/edge$/",
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)metadata\\.yaml$"],
+      "matchStrings": [
+        "upstream-source:\\s*(?<depName>[^:\\s]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^src/constants\\.py$"],
+      "matchStrings": [
+        "(?<variableName>JOB_OCI_IMAGE|GPU_JOB_OCI_IMAGE)\\s*=\\s*\"(?<depName>[^:\\s]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/canonical/charmed-spark",
+        "ghcr.io/canonical/charmed-spark-gpu"
+        "ghcr.io/canonical/charmed-spark-kyuubi",
+      ],
+      "pinDigests": true,
+      "allowedVersions": "/^3\\.4-/",
+      "groupName": "OCI resources"
+    }
   ]
 }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,8 +34,7 @@ resources:
   kyuubi-image:
     type: oci-image
     description: OCI image for kyuubi
-    # spark-3.4.4, kyuubi 1.10.3 release date 17/03/2026
-    upstream-source: ghcr.io/canonical/charmed-spark-kyuubi@sha256:60e81dd2e9be50d4a857ce987935341c8518c784c7de36e814fc41dd3451d58f
+    upstream-source: ghcr.io/canonical/charmed-spark-kyuubi:3.4-22.04_edge@sha256:60e81dd2e9be50d4a857ce987935341c8518c784c7de36e814fc41dd3451d58f
 
 peers:
   kyuubi-peers:

--- a/src/constants.py
+++ b/src/constants.py
@@ -30,10 +30,8 @@ JDBC_PORT = 10009
 REST_PORT = 10099
 SPARK_DEFAULT_CATALOG_NAME = "spark_catalog"
 
-# spark-3.4.4-22.04, release date 17/03/2026
-JOB_OCI_IMAGE = "ghcr.io/canonical/charmed-spark@sha256:ce0faa3028aa201110732065beedbcfd9f016ba7a7ed758538475bba77fb650a"
-# spark-gpu-3.4.4-22.04, release date 17/03/2026
-GPU_JOB_OCI_IMAGE = "ghcr.io/canonical/charmed-spark-gpu@sha256:e36e72bfd30ac19983faa290fa60fe4c0d9853e5c5bbc73cd18aec1e8e0ccca4"
+JOB_OCI_IMAGE = "ghcr.io/canonical/charmed-spark:3.4-22.04_edge@sha256:ce0faa3028aa201110732065beedbcfd9f016ba7a7ed758538475bba77fb650a"
+GPU_JOB_OCI_IMAGE = "ghcr.io/canonical/charmed-spark-gpu:3.4-22.04_edge@sha256:e36e72bfd30ac19983faa290fa60fe4c0d9853e5c5bbc73cd18aec1e8e0ccca4"
 
 DEFAULT_ADMIN_USERNAME = "admin"
 PASSWORD_SUFFIX = "-password"

--- a/tests/unit/test_components_refresh.py
+++ b/tests/unit/test_components_refresh.py
@@ -8,30 +8,44 @@ from subprocess import check_output
 import pytest
 import yaml
 
-from constants import JOB_OCI_IMAGE
+from constants import GPU_JOB_OCI_IMAGE, JOB_OCI_IMAGE
 from events.refresh import is_workload_compatible
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 
 
 def inspect_image(skopeo: str, image: str) -> dict:
-    out = check_output([skopeo, "inspect", f"docker://{image}", "--no-creds"])
+    out = check_output([skopeo, "inspect", f"docker://{image}", "--no-creds", "-n"])
     return json.loads(out)
 
 
+@pytest.mark.slow
 def test_images_same_spark_version(skopeo: str) -> None:
     # Given
     charm_workload_image = METADATA["resources"]["kyuubi-image"]["upstream-source"]
     job_image = JOB_OCI_IMAGE
+    gpu_job_image = GPU_JOB_OCI_IMAGE
+
+    # we need to strip the tag, as skopeo does not support having both a tag and a digest
+    image, _, digest = charm_workload_image.split(":")
+    charm_workload_image = f"{image}@sha256:{digest}"
+    image, _, digest = job_image.split(":")
+    job_image = f"{image}@sha256:{digest}"
+    image, _, digest = gpu_job_image.split(":")
+    gpu_job_image = f"{image}@sha256:{digest}"
 
     # When
     workload_version = inspect_image(skopeo, charm_workload_image)["Labels"][
         "org.opencontainers.image.version"
     ]
     job_version = inspect_image(skopeo, job_image)["Labels"]["org.opencontainers.image.version"]
+    gpu_job_version = inspect_image(skopeo, gpu_job_image)["Labels"][
+        "org.opencontainers.image.version"
+    ]
 
     # Then
     assert workload_version == job_version
+    assert workload_version == gpu_job_version
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR is similar to the other charms. 
However, we have a slightly more complex setup, since we also want to track and update the resources used to run the spark job.

Here is an example in my own fork of what a renovate PR would look like: https://github.com/Batalex/kyuubi-k8s-operator/pull/1