### PR TITLE
[MISC] Add appropriate workflow permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,9 @@ on:
   schedule:
     - cron: "53 0 * * *" # Daily at 00:53 UTC
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,9 @@ jobs:
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v48.1.1
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: read
 
   integration-test:
     strategy:

--- a/.github/workflows/integration-gpu.yaml
+++ b/.github/workflows/integration-gpu.yaml
@@ -11,6 +11,9 @@ on:
         default: "amd64"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner

--- a/.github/workflows/refresh-tests.yaml
+++ b/.github/workflows/refresh-tests.yaml
@@ -6,6 +6,9 @@ name: Inplace refresh tests
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test-refresh:
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,9 @@ on:
       - 3.4/edge
       - 3.5/edge
 
+permissions:
+  contents: read
+
 jobs:
 
   release-checks:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,7 +63,8 @@ jobs:
     with:
       track: ${{ needs.release-checks.outputs.track }}
     permissions:
-      contents: write # Needed to create git tag
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: write  # Needed to create git tags
 
   ci-tests:
     uses: ./.github/workflows/ci.yaml
@@ -83,4 +84,5 @@ jobs:
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
-      contents: write # Needed to create git tags
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: write  # Needed to create git tags

--- a/.github/workflows/tiobe_scan.yaml
+++ b/.github/workflows/tiobe_scan.yaml
@@ -9,6 +9,9 @@ on:
     - cron: "0 2 * * 6" # Every Saturday 2:00 AM UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tiobe-scan:
     name: Tiobe scan


### PR DESCRIPTION
The data-platform-workflows have opted to use explicit workflow permissions recently, via https://github.com/canonical/data-platform-workflows/pull/344