### PR TITLE
[MISC] Update release checks to infer spark version from tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,10 +29,13 @@ jobs:
           echo "track=${BRANCH%*\/*}" >> $GITHUB_OUTPUT
         id: branch_metadata
 
+      - name: Install yq
+        run: sudo snap install yq
+
       - name: Extract metadata
         shell: bash
         run: |
-          VERSION=$(grep "\w*# spark-" metadata.yaml | sed "s/.*spark-\([0-9.]*\).*/\1/g")
+          VERSION=$(yq '.resources.kyuubi-image.upstream-source' metadata.yaml | sed -n "s/.*:\([0-9]*\.[0-9]*\)-.*/\1/p")
           BASE=$(yq '.platforms' charmcraft.yaml | sed -n "s/ubuntu\@\([0-9\.]*\)\:.*/\1/p" | tail -n1)
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "base=${BASE}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixes the CI run failure here: https://github.com/canonical/kyuubi-k8s-operator/actions/runs/24656664446/job/72091777646#step:4:1

Tested using CLI on all branches:

<img width="1297" height="310" alt="image" src="https://github.com/user-attachments/assets/78319ab9-10f6-4619-b7d6-30b8c351b17b" />
