### PR TITLE
[PRA-264] Fix TIOBE workflow

### DIFF
--- a/.github/workflows/tiobe_scan.yaml
+++ b/.github/workflows/tiobe_scan.yaml
@@ -47,7 +47,7 @@ jobs:
           echo PATH="$PATH" >> "$GITHUB_ENV"
 
       - name: Run tox tests to create coverage.xml
-        run: tox run -e unit
+        run: tox run -e unit -- -m "not skopeo"
 
       - name: Move results to necessary folder for TICS
         run: |

--- a/.github/workflows/tiobe_scan.yaml
+++ b/.github/workflows/tiobe_scan.yaml
@@ -1,7 +1,6 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-
 name: TICS run self-hosted test (github-action)
 
 on:
@@ -23,15 +22,9 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt-get update 
-          sudo apt-get install -y python3-venv
-          sudo apt-get install -y libpq-dev python3-dev
-
-      - name: Install pipx
-        run: python3 -m pip install --user pipx && python3 -m pipx ensurepath
-
-      - name: Add pipx to PATH
-        run: echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          sudo apt update
+          sudo apt install -y libpq-dev pipx python3-dev python3-venv
+          pipx ensurepath
 
       - name: Install tox and poetry using pipx
         run: |

--- a/tests/unit/test_components_refresh.py
+++ b/tests/unit/test_components_refresh.py
@@ -19,7 +19,7 @@ def inspect_image(skopeo: str, image: str) -> dict:
     return json.loads(out)
 
 
-@pytest.mark.slow
+@pytest.mark.skopeo
 def test_images_same_spark_version(skopeo: str) -> None:
     # Given
     charm_workload_image = METADATA["resources"]["kyuubi-image"]["upstream-source"]


### PR DESCRIPTION
This PR fixes the broken TIOBE workflow that had gone unnoticed for a while.

The root cause was simple: we (and by "we", I mean "I") introduced a while ago a test using `skopeo` to check the compatibility between the various OCI resources involved.

Instead of installing the tool in the runner, I deselected this specific test since it does not contribute to the testing coverage and makes external network calls. I don't have the strongest of opinions here, so I'm happy to proceed the other way around and install `skopeo` on the runner.

You can check in the action tab that we now have a green run from the workflow (and even check the dashboard with a new quality measurement from today). Since I removed the commit in this PR running the workflow on pull request, the thing is a bit hidden. 