### PR TITLE
[MISC] Enable renovate on track 4, fix oci updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,9 +11,7 @@
     "schedule": ["* 1-6 1-7 * 5"]
   },
   "ignoreDeps": ["ubuntu"],
-  "baseBranchPatterns": [
-    "/^3\\..*\\/edge$/",
-  ],
+  "baseBranchPatterns": ["/^[0-9]+\\.[0-9]+\\/edge$/"],
   "customManagers": [
     {
       "customType": "regex",
@@ -21,7 +19,8 @@
       "matchStrings": [
         "#\\s*oci-tag=(?<currentValue>[^\\s]+)\\r?\\n\\s*upstream-source:\\s*(?<depName>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
       ],
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     },
     {
       "customType": "regex",
@@ -29,7 +28,8 @@
       "matchStrings": [
         "(?<variableName>JOB_OCI_IMAGE|GPU_JOB_OCI_IMAGE)\\s*=\\s*\"(?<depName>[^:\\s]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
       ],
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     }
   ],
   "packageRules": [
@@ -38,11 +38,26 @@
       "matchPackageNames": [
         "ghcr.io/canonical/charmed-spark",
         "ghcr.io/canonical/charmed-spark-gpu",
-        "ghcr.io/canonical/charmed-spark-kyuubi",
+        "ghcr.io/canonical/charmed-spark-kyuubi"
       ],
       "pinDigests": true,
-      "allowedVersions": "/^3\\.5-/",
-      "groupName": "OCI resources"
+      "groupName": "OCI resources",
+      "description": "Only allow digest updates for the current track. Block all version bumps.",
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "enabled": false
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/canonical/charmed-spark",
+        "ghcr.io/canonical/charmed-spark-gpu",
+        "ghcr.io/canonical/charmed-spark-kyuubi"
+      ],
+      "pinDigests": true,
+      "groupName": "OCI resources",
+      "description": "Only allow digest updates for the current track. Block all version bumps.",
+      "matchUpdateTypes": ["digest"],
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
This PR fixes the OCI update so that #221 does not happen again. See https://github.com/Batalex/kyuubi-k8s-operator/pull/1 for an example where the 3.4 branch only receive 3.4 updates.

In addition, it also enables renovate on track 4.