### PR TITLE
feat: non-root user compliance

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,9 +26,13 @@ maintainers:
 assumes:
   - k8s-api
 
+charm-user: non-root
+
 containers:
   kyuubi:
     resource: kyuubi-image
+    uid: 584792
+    gid: 584792
 
 resources:
   kyuubi-image:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -28,7 +28,7 @@ import yaml
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.x509 import load_pem_x509_certificate
-from lightkube.resources.core_v1 import Service
+from lightkube.resources.core_v1 import Pod, Service
 from spark8t.domain import PropertyFile
 from spark_test.core.kyuubi import KyuubiClient
 
@@ -824,3 +824,58 @@ def verify_certificate_matches_public_key(certificate: bytes, public_key: bytes)
     )
 
     return cert_pubkey_bytes == given_pubkey_bytes
+
+
+class ContainerSecurityContext(dict):
+    """TypedDict representing Kubernetes container security context settings."""
+
+    runAsUser: int | None  # noqa N815
+    runAsGroup: int | None  # noqa N815
+
+
+def generate_container_securitycontext_map(
+    metadata_yaml: dict, juju_user_id: int = 170
+) -> dict[str, ContainerSecurityContext]:
+    """Generate a mapping of container names to their security context UID/GID settings."""
+    c_uid_map = {}
+    for k, v in metadata_yaml.get("containers", {}).items():
+        c_uid_map[k] = ContainerSecurityContext(
+            runAsUser=v["uid"],
+            runAsGroup=v["gid"],
+        )
+    c_uid_map["charm"] = {"runAsUser": juju_user_id, "runAsGroup": juju_user_id}
+    return c_uid_map
+
+
+def get_pod_names(model: str, application_name: str) -> list[str]:
+    """Retrieve names of all pods belonging to a specific Juju application."""
+    cmd = [
+        "kubectl",
+        "get",
+        "pods",
+        f"-n{model}",
+        f"-lapp.kubernetes.io/name={application_name}",
+        "--no-headers",
+        "-o=custom-columns=NAME:.metadata.name",
+    ]
+    proc = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+    )
+    stdout = proc.stdout.decode("utf8")
+    return stdout.split()
+
+
+def assert_security_context(
+    lightkube_client: lightkube.Client,
+    pod_name: str,
+    container_name: str,
+    container_securitycontext_map: dict[str, ContainerSecurityContext],
+    model_name: str,
+) -> None:
+    """Assert that a container's security context matches expected UID/GID settings."""
+    containers: list = lightkube_client.get(Pod, pod_name, namespace=model_name).spec.containers
+    container = next((c for c in containers if c.name == container_name), None)
+    security_context = container.securityContext
+    for key, value in container_securitycontext_map.get(container_name).items():
+        assert getattr(security_context, key) == value

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -843,7 +843,7 @@ def generate_container_securitycontext_map(
             runAsUser=v["uid"],
             runAsGroup=v["gid"],
         )
-    c_uid_map["charm"] = {"runAsUser": juju_user_id, "runAsGroup": juju_user_id}
+    c_uid_map["charm"] = ContainerSecurityContext(runAsUser=juju_user_id, runAsGroup=juju_user_id)
     return c_uid_map
 
 
@@ -874,8 +874,14 @@ def assert_security_context(
     model_name: str,
 ) -> None:
     """Assert that a container's security context matches expected UID/GID settings."""
-    containers: list = lightkube_client.get(Pod, pod_name, namespace=model_name).spec.containers
+    pod = lightkube_client.get(Pod, pod_name, namespace=model_name)
+    assert pod.spec is not None
+    containers: list = pod.spec.containers
     container = next((c for c in containers if c.name == container_name), None)
+    assert container is not None
     security_context = container.securityContext
-    for key, value in container_securitycontext_map.get(container_name).items():
+    assert security_context is not None
+    expected = container_securitycontext_map.get(container_name)
+    assert expected is not None
+    for key, value in expected.items():
         assert getattr(security_context, key) == value

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -7,12 +7,17 @@ from pathlib import Path
 from typing import cast
 
 import jubilant
+import lightkube
+import pytest
 import yaml
 
 from core.domain import Status
 
 from .helpers import (
+    assert_security_context,
     fetch_connection_info,
+    generate_container_securitycontext_map,
+    get_pod_names,
     validate_sql_queries_with_kyuubi,
 )
 from .types import IntegrationTestsCharms, S3Info
@@ -21,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
+CONTAINERS_SECURITY_CONTEXT_MAP = generate_container_securitycontext_map(METADATA)
 
 
 def test_build_and_deploy_kyuubi(juju: jubilant.Juju, kyuubi_charm: Path) -> None:
@@ -155,6 +161,27 @@ def test_enable_authentication(
         lambda status: jubilant.all_active(status, APP_NAME, charm_versions.auth_db.app),
         delay=20,
         timeout=1000,
+    )
+
+
+@pytest.mark.parametrize("container_name", list(CONTAINERS_SECURITY_CONTEXT_MAP.keys()))
+def test_container_security_context(
+    juju: jubilant.Juju,
+    container_name: str,
+) -> None:
+    """Test container security context is correctly set.
+
+    Verify that container spec defines the security context with correct
+    user ID and group ID.
+    """
+    lightkube_client = lightkube.Client()
+    pod_name = get_pod_names(juju.model, APP_NAME)[0]
+    assert_security_context(
+        lightkube_client,
+        pod_name,
+        container_name,
+        CONTAINERS_SECURITY_CONTEXT_MAP,
+        juju.model,
     )
 
 


### PR DESCRIPTION
## Assessment
| Component | Status | Details |
|-----------|--------|---------|
| **Charm container** | ❌ Non-compliant | `charm-user` was not set in `metadata.yaml` |
| **Workload container (kyuubi)** | ❌ Non-compliant | `uid` and `gid` were not set to `584792` |
| **Upstream image permissions** | ✅ Compliant | The upstream image (`ghcr.io/canonical/charmed-spark-kyuubi`) runs as `_daemon_` (uid=584792, gid=584792); `/opt/kyuubi/conf` and `/etc/spark8t/conf` are owned by `_daemon_` with `rwxr-x---` permissions |
| **Pebble operations** | ✅ Compliant | All read/write operations target paths under `/opt/kyuubi/conf` and `/etc/spark8t/conf`, both owned by `_daemon_` |

## Mitigation
- Added `charm-user: non-root` to `metadata.yaml`
- Set `uid: 584792` and `gid: 584792` for the `kyuubi` container in `metadata.yaml`
- No image rebuild required — upstream image already runs as `_daemon_` with correct permissions

## Verification
- Added `generate_container_securitycontext_map`, `get_pod_names`, and `assert_security_context` helper functions to `tests/integration/helpers.py`
- Added `test_container_security_context` parametrized integration test in `tests/integration/test_charm.py`, placed after `test_enable_authentication` which deploys the charm and waits for active status