### PR TITLE
[PRA-354] Migrate and improve renovate config (3.5)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,63 +1,76 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
     "github>canonical/data-platform//renovate_presets/charm.json5",
+    "helpers:pinGitHubActionDigests",
   ],
-  "reviewers": ["team:processing"],
-  // Between 1AM and 6:59AM, first Friday of the month
-  "schedule": ["* 1-6 1-7 * 5"],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["* 1-6 1-7 * 5"]
+  baseBranchPatterns: ["/^3\\/edge$/", "/^4\\/edge$/"],
+  useBaseBranchConfig: "merge",
+  // Between 1AM and 6:59AM, Friday mid-month
+  schedule: ["* 1-6 14-21 * 5"],
+  lockFileMaintenance: {
+    enabled: true,
+    // Between 1AM and 6:59AM, first Friday of the month
+    schedule: ["* 1-6 1-7 * 5"],
   },
-  "ignoreDeps": ["ubuntu"],
-  "baseBranchPatterns": ["/^[0-9]+\\.[0-9]+\\/edge$/"],
-  "customManagers": [
+  commitMessagePrefix: "[RENOVATE] ",
+  ignoreDeps: ["ubuntu"],
+  baseBranchPatterns: ["/^[0-9]+\\.[0-9]+\\/edge$/"],
+  useBaseBranchConfig: "merge",
+  customManagers: [
     {
-      "customType": "regex",
-      "fileMatch": ["(^|/)metadata\\.yaml$"],
-      "matchStrings": [
-        "#\\s*oci-tag=(?<currentValue>[^\\s]+)\\r?\\n\\s*upstream-source:\\s*(?<depName>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      customType: "regex",
+      managerFilePatterns: ["metadata.yaml"],
+
+      matchStrings: [
+        "#\\s*oci-tag=(?<currentValue>[^\\s]+)\\r?\\n\\s*upstream-source:\\s*(?<depName>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)",
       ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "docker"
+      datasourceTemplate: "docker",
+      versioningTemplate: "docker",
     },
     {
-      "customType": "regex",
-      "fileMatch": ["^src/constants\\.py$"],
-      "matchStrings": [
-        "(?<variableName>JOB_OCI_IMAGE|GPU_JOB_OCI_IMAGE)\\s*=\\s*\"(?<depName>[^:\\s]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
+      customType: "regex",
+      managerFilePatterns: ["src/constants.py"],
+
+      matchStrings: [
+        '(?<variableName>JOB_OCI_IMAGE|GPU_JOB_OCI_IMAGE)\\s*=\\s*"(?<depName>[^:\\s]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"',
       ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "docker"
-    }
+      datasourceTemplate: "docker",
+      versioningTemplate: "docker",
+    },
   ],
-  "packageRules": [
+  packageRules: [
     {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": [
+      matchDatasources: ["docker"],
+      matchPackageNames: [
         "ghcr.io/canonical/charmed-spark",
         "ghcr.io/canonical/charmed-spark-gpu",
-        "ghcr.io/canonical/charmed-spark-kyuubi"
+        "ghcr.io/canonical/charmed-spark-kyuubi",
       ],
-      "pinDigests": true,
-      "groupName": "OCI resources",
-      "description": "Only allow digest updates for the current track. Block all version bumps.",
-      "matchUpdateTypes": ["major", "minor", "patch"],
-      "enabled": false
+      pinDigests: true,
+      groupName: "OCI resources",
+      description: "Only allow digest updates for the current track. Block all version bumps.",
+      matchUpdateTypes: ["major", "minor", "patch"],
+      enabled: false,
     },
     {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": [
+      matchDatasources: ["docker"],
+      matchPackageNames: [
         "ghcr.io/canonical/charmed-spark",
         "ghcr.io/canonical/charmed-spark-gpu",
-        "ghcr.io/canonical/charmed-spark-kyuubi"
+        "ghcr.io/canonical/charmed-spark-kyuubi",
       ],
-      "pinDigests": true,
-      "groupName": "OCI resources",
-      "description": "Only allow digest updates for the current track. Block all version bumps.",
-      "matchUpdateTypes": ["digest"],
-      "enabled": true
-    }
-  ]
+      pinDigests: true,
+      groupName: "OCI resources",
+      description: "Only allow digest updates for the current track. Block all version bumps.",
+      matchUpdateTypes: ["digest"],
+      enabled: true,
+    },
+    {
+      description: "Combine all charmcraft|charmcraft.yaml & src/constants.py dependencies into a single PR",
+      matchFileNames: ["charmcraft.yaml", "metadata.yaml", "src/constants.py"],
+      groupName: "Charm dependencies",
+      groupSlug: "charm-deps",
+    },
+  ],
 }


### PR DESCRIPTION
Similar to what we did in other repositories, this PR:
- pins the GH actions to their exact digest
- removes the reviewers 
- Merges the charmcraft updates + the OCI updates in one PR
- Tries to schedule the PRs in the least obstrusive way
- Adds the `[RENOVATE] ` prefix